### PR TITLE
Speed up removeIndices

### DIFF
--- a/pangolin/scripts/pangolearn.py
+++ b/pangolin/scripts/pangolearn.py
@@ -128,8 +128,11 @@ def removeIndices(headersFile):
 
 		finalLine = []
 
-		for index in range(len(line)):
-			if index in indiciesToKeep:
+		#for index in range(len(line)):
+		#	if index in indiciesToKeep:
+		#		finalLine.extend(line[index].vector)
+		for index in indiciesToKeep:
+			if index < len(line):
 				finalLine.extend(line[index].vector)
 
 		finalList.append(finalLine)
@@ -146,6 +149,8 @@ readInAndFormatData()
 print("removing unnecessary columns " + datetime.now().strftime("%m/%d/%Y, %H:%M:%S"));
 
 dataList, headers = removeIndices(headerFile)
+
+print("constructing data frame" + datetime.now().strftime("%m/%d/%Y, %H:%M:%S"));
 
 df = pd.DataFrame(dataList, columns=headers)
 

--- a/pangolin/scripts/pangolearn.py
+++ b/pangolin/scripts/pangolearn.py
@@ -128,9 +128,6 @@ def removeIndices(headersFile):
 
 		finalLine = []
 
-		#for index in range(len(line)):
-		#	if index in indiciesToKeep:
-		#		finalLine.extend(line[index].vector)
 		for index in indiciesToKeep:
 			if index < len(line):
 				finalLine.extend(line[index].vector)
@@ -150,7 +147,7 @@ print("removing unnecessary columns " + datetime.now().strftime("%m/%d/%Y, %H:%M
 
 dataList, headers = removeIndices(headerFile)
 
-print("constructing data frame" + datetime.now().strftime("%m/%d/%Y, %H:%M:%S"));
+#print("constructing data frame " + datetime.now().strftime("%m/%d/%Y, %H:%M:%S"));
 
 df = pd.DataFrame(dataList, columns=headers)
 


### PR DESCRIPTION
Reduces computing time from about 6 minutes to about 20 seconds by iterating over accepted indices (genome positions) only instead of entire genome.  Please see https://github.com/ArtPoon/pangolin/issues/1