### PR TITLE
Reduces memory requirements, faster processing

### DIFF
--- a/pangolin/command.py
+++ b/pangolin/command.py
@@ -115,6 +115,9 @@ def main(sysargs = sys.argv[1:]):
     do_not_run = []
     run = []
     for record in SeqIO.parse(query, "fasta"):
+        # replace spaces in sequence headers with underscores
+        record.id = record.description.replace(' ', '_')
+
         if len(record) <args.minlen:
             record.description = record.description + f" fail=seq_len:{len(record)}"
             do_not_run.append(record)


### PR DESCRIPTION
I'm sorry about the extensive modifications - I've tried to adhere to the overall code style (e.g., inline comments instead of docstrings, camelCase variable names).  Please let me know if there are any modifications you need me to make.

`pangolearn.py`:
* script used a mixture of tabs and spaces for indentation, set to 4 space indentation for consistency with other scripts in this module and PEP8
* avoiding implicit use of global namespace variables within functions
* simplified `getOneHotEncoding` function
* `readInAndFormatData` now streams records from FASTA file and excludes unused sites, yields outputs in chunks of size 1000 records (`blockSize`) to prevent script from eating up RAM.
* replaced exhaustive linear search with `sort` for `maxScore` (predictions)
* tested original script against this version for over 24K genome records from the UK
* total compute time reduced from about 24hrs to ~30mins for about 24K records.
