### PR TITLE
Added shebang to pangolearn.py

### DIFF
--- a/pangolin/scripts/pangolearn.py
+++ b/pangolin/scripts/pangolearn.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python 
+
 import pandas as pd
 from sklearn.model_selection import train_test_split
 from sklearn.linear_model import LogisticRegression


### PR DESCRIPTION
Hi Pangolin team,

I had an issue with running the git master of pangolin installed with pip.
Here is the error message: 


<details><summary>CLICK ME</summary>
<p>

```python
 pangolin results/aligned.fasta -t 64 -p --outdir test --no-temp
Found the snakefile
The query file is /<absolute path>/results/aligned.fasta
--no-temp: All intermediate files will be written to /<absolute path>/test
Number of threads is 64
Looking in /home/<username>/miniconda3/envs/pangolin/lib/python3.6/site-packages/pangoLEARN/data for data files...

Data files found
Trained model:  /home/<username>/miniconda3/envs/pangolin/lib/python3.6/site-packages/pangoLEARN/data/multinomialLogReg_v1.joblib
Header file:    /home/<username>/miniconda3/envs/pangolin/lib/python3.6/site-packages/pangoLEARN/data/multinomialLogRegHeaders_v1.joblib
Lineages csv:   /home/<username>/miniconda3/envs/pangolin/lib/python3.6/site-packages/pangoLEARN/data/lineages.metadata.csv
Job counts:
        count   jobs
        1       add_failed_seqs
        1       all
        1       datafunk_trim_and_pad
        1       minimap2_check_distance
        1       minimap2_to_reference
        1       pangolearn
        1       parse_paf
        7

        minimap2 -x asm5 /home/<username>/miniconda3/envs/pangolin/lib/python3.6/site-packages/pangolin/data/reference.fasta /<absolute path>/test/query.post_qc.fasta -o /<absolute path>/test/reference_mapped.paf &> /<absolute path>/test/logs/minimap2_check.log
        
Job counts:
        count   jobs
        1       parse_paf
        1

        minimap2 -a -x asm5 /home/<username>/miniconda3/envs/pangolin/lib/python3.6/site-packages/pangolin/data/reference.fasta /<absolute path>/test/mappable.fasta -o /<absolute path>/test/reference_mapped.sam &> /<absolute path>/test/logs/minimap2_sam.log
        

        datafunk sam_2_fasta           -s /<absolute path>/test/reference_mapped.sam           -r /home/<username>/miniconda3/envs/pangolin/lib/python3.6/site-packages/pangolin/data/reference.fasta           -o /<absolute path>/test/post_qc_query.aligned.fasta           -t [265:29674]           --pad           --log-inserts 
        

        pangolearn.py --header-file /home/<username>/miniconda3/envs/pangolin/lib/python3.6/site-packages/pangoLEARN/data/multinomialLogRegHeaders_v1.joblib --model-file /home/<username>/miniconda3/envs/pangolin/lib/python3.6/site-packages/pangoLEARN/data/multinomialLogReg_v1.joblib --fasta /<absolute path>/test/post_qc_query.aligned.fasta -o /<absolute path>/test/lineage_report.pass_qc.csv
        
import-im6.q16: unable to open X server `' @ error/import.c/ImportImageCommand/358.
from: can't read /var/mail/sklearn.model_selection
from: can't read /var/mail/sklearn.linear_model
from: can't read /var/mail/sklearn
from: can't read /var/mail/sklearn.datasets
from: can't read /var/mail/sklearn.model_selection
from: can't read /var/mail/sklearn.metrics
from: can't read /var/mail/datetime
import-im6.q16: unable to open X server `' @ error/import.c/ImportImageCommand/358.
import-im6.q16: unable to open X server `' @ error/import.c/ImportImageCommand/358.
import-im6.q16: unable to open X server `' @ error/import.c/ImportImageCommand/358.
/home/<username>/miniconda3/envs/pangolin/bin/pangolearn.py: line 13: dataList: command not found
/home/<username>/miniconda3/envs/pangolin/bin/pangolearn.py: line 14: tempDataLines: command not found
/home/<username>/miniconda3/envs/pangolin/bin/pangolearn.py: line 15: idList: command not found
/home/<username>/miniconda3/envs/pangolin/bin/pangolearn.py: line 17: syntax error near unexpected token `('
/home/<username>/miniconda3/envs/pangolin/bin/pangolearn.py: line 17: `def parse_args():'
[Wed Jul 29 13:53:40 2020]
Error in rule pangolearn:
    jobid: 2
    output: /<absolute path>/test/lineage_report.pass_qc.csv
    shell:
        
        pangolearn.py --header-file /home/<username>/miniconda3/envs/pangolin/lib/python3.6/site-packages/pangoLEARN/data/multinomialLogRegHeaders_v1.joblib --model-file /home/<username>/miniconda3/envs/pangolin/lib/python3.6/site-packages/pangoLEARN/data/multinomialLogReg_v1.joblib --fasta /<absolute path>/test/post_qc_query.aligned.fasta -o /<absolute path>/test/lineage_report.pass_qc.csv
        
        (one of the commands exited with non-zero exit code; note that snakemake uses bash strict mode!)

Exiting because a job execution failed. Look above for error message
```

</p>
</details>

I was able to fix it with the little change below.
Is possible to merge it into the master? 

Thank you for developing Pangolin.

Cheers, 
TheBready

