### PR TITLE
Add Dockerfile and Github Actions workflow for building and pushing Docker container to Docker Hub

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+.dockerignore

--- a/.github/workflows/push_dockerhub.yml
+++ b/.github/workflows/push_dockerhub.yml
@@ -1,0 +1,41 @@
+name: Docker push
+# This builds the docker image and pushes it to DockerHub
+# Runs on cov-lineages/pangolin repo releases
+# and push event to 'dev' branch (PR merges)
+on:
+  push:
+    branches:
+      - dev
+  release:
+    types: [published]
+
+jobs:
+  push_dockerhub:
+    name: Push new Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    # Only run for the cov-lineages/pangolin repo, for releases and merged PRs
+    if: ${{ github.repository == 'cov-lineages/pangolin' }}
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}
+    steps:
+      - name: Check out pipeline code
+        uses: actions/checkout@v2
+
+      - name: Build new docker image
+        run: docker build --no-cache . -t covlineages/pangolin:latest
+
+      - name: Push Docker image to DockerHub (dev)
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+          docker tag cov-lineages/pangolin:latest covlineages/pangolin:dev
+          docker push cov-lineages/pangolin:dev
+
+      - name: Push Docker image to DockerHub (release)
+        if: ${{ github.event_name == 'release' }}
+        run: |
+          echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+          docker push covlineages/pangolin:latest
+          docker tag covlineages/pangolin:latest covlineages/pangolin:${{ github.event.release.tag_name }}
+          docker push covlineages/pangolin:${{ github.event.release.tag_name }}

--- a/.github/workflows/push_dockerhub.yml
+++ b/.github/workflows/push_dockerhub.yml
@@ -29,8 +29,8 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         run: |
           echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-          docker tag cov-lineages/pangolin:latest covlineages/pangolin:dev
-          docker push cov-lineages/pangolin:dev
+          docker tag covlineages/pangolin:latest covlineages/pangolin:dev
+          docker push covlineages/pangolin:dev
 
       - name: Push Docker image to DockerHub (release)
         if: ${{ github.event_name == 'release' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,27 @@
 FROM continuumio/miniconda3:4.9.2-alpine
-LABEL authors="" \
-      version="2.1.2" \
+LABEL version="2.1.2" \
       description="Docker image for Pangolin"
 
 # Install git for pangolin
 RUN apk update && \
     apk add git bash
 
+COPY environment.yml /environment.yml
+# Python 3.8.5 already installed along with recent version of pip
+# so remove Python and pip deps from environment.yml before installation
+RUN sed -i "$(grep -n python=3.7 /environment.yml | cut -f1 -d:)d" /environment.yml && \
+    sed -i "$(grep -n pip= /environment.yml | cut -f1 -d:)d" /environment.yml
 # Install the conda environment
-COPY environment.yml /
-COPY . /pangolin/
 RUN conda env create --quiet -f /environment.yml && conda clean -a
-
 # Add conda installation dir to PATH (instead of doing 'conda activate')
 ENV PATH /opt/conda/envs/pangolin/bin:$PATH
+
+# Install Pangolin
+COPY . /pangolin/
 WORKDIR /pangolin/
-RUN pip install -e .
-RUN pangolin --version &> pangolin-version.txt
+RUN pip install . && rm -rf /root/.cache/pip
+RUN pangolin --version &> /pangolin-version.txt
 
 # Dump the details of the installed packages to a file for posterity
-RUN conda env export --name pangolin > pangolin.yml
+RUN conda env export --name pangolin > /pangolin.yml
+WORKDIR /tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM continuumio/miniconda3:4.9.2-alpine
+LABEL authors="" \
+      version="2.1.2" \
+      description="Docker image for Pangolin"
+
+# Install git for pangolin
+RUN apk update && \
+    apk add git bash
+
+# Install the conda environment
+COPY environment.yml /
+COPY . /pangolin/
+RUN conda env create --quiet -f /environment.yml && conda clean -a
+
+# Add conda installation dir to PATH (instead of doing 'conda activate')
+ENV PATH /opt/conda/envs/pangolin/bin:$PATH
+WORKDIR /pangolin/
+RUN pip install -e .
+RUN pangolin --version &> pangolin-version.txt
+
+# Dump the details of the installed packages to a file for posterity
+RUN conda env export --name pangolin > pangolin.yml


### PR DESCRIPTION
Hello!

This PR adds:

- a `Dockerfile` for building a Docker container for Pangolin and its dependencies
- a Github Actions workflow for building an image and pushing it to [Docker Hub](https://hub.docker.com/)

I currently have the Docker Hub organization or Docker ID set as `covlineages` (which [doesn't exist yet](https://hub.docker.com/u/covlineages)). Docker Hub doesn't allow dashes in the [Docker ID](https://docs.docker.com/docker-id/#register-for-a-docker-id) so had to remove the dash.

If a Docker Hub org/user is created (e.g. `covlineages`), then to enable pushing, in this repo's settings, you need to set the following secrets:

- `DOCKERHUB_USERNAME`: Docker Hub username
- `DOCKERHUB_PASS`: Docker Hub password

The size of the Docker image is 1.05GB


## Testing

Below are some commands to test the proposed additions:

```bash
git clone -b add-docker https://github.com/peterk87/pangolin
cd pangolin
# build Docker container with tag covlineages/pangolin
DOCKER_BUILDKIT=1 docker build -t covlineages/pangolin .
# check version of pangolin in newly created docker container
docker run --rm covlineages/pangolin pangolin --version
# run on test data with docker container "pangolin"
docker run \
  -v $PWD:/tmp/ \
  --user $(id -u):$(id -g) \
  --workdir /tmp/ \
  covlineages/pangolin \
  pangolin pangolin/test/test_seqs.fasta
# should output to lineage_report.csv
cat lineage_report.csv
# taxon,lineage,probability,pangoLEARN_version,status,note
# Wuhan/WH04/2020,A,1.0,2020-12-17,passed_qc,
# Japan/DP0779/2020|EPI_ISL_416626||Japan|unknown||2020-02-17,B,1.0,2020-12-17,passed_qc,
# USA/NY-NYUMC7/2020|EPI_ISL_418192||USA|New_York|Manhattan|2020-03-16,B.1.314,1.0,2020-12-17,passed_qc,
# This_seq_has_no_seq,None,0,2020-12-17,fail,seq_len:0
# This_seq_is_too_short,None,0,2020-12-17,fail,seq_len:2997
# This_seq_has_lots_of_Ns,None,0,2020-12-17,fail,N_content:0.98
# This_seq_is_literally_just_N,None,0,2020-12-17,fail,N_content:1.0
# issue_57_torsten_seq,None,0,2020-12-17,fail,failed to map
# This_seq_has_6000_Ns_in_18000_bases,None,0,2020-12-17,fail,failed to map
```

## Why?

Easier integration with workflow managers such as Nextflow, Snakemake and others that can use Docker containers.

### Example Nextflow workflow

Below is a very basic Nextflow workflow to run Pangolin on some input FASTA files using the Docker container built above tagged as "pangolin" (see `nextflow.config`).

Usage:

```bash
nextflow run main.nf -profile docker --input pangolin/test/test_seqs.fasta
```

with Pangolin output and logs in "$PWD/results/pangolin/"

Once the image is on Docker Hub, it would also be possible to the run workflow with a [Singularity](https://sylabs.io/guides/3.7/user-guide/introduction.html) container automatically created from the Docker container for execution on an HPC cluster (e.g. `nextflow run main.nf -profile singularity ...`).


`main.nf` workflow definition:

```nextflow
#!/usr/bin/env nextflow
nextflow.enable.dsl=2

params.outdir = "results"
params.input = "*.fasta"

process PANGOLIN {
  publishDir "${params.outdir}/pangolin",
             pattern: "*.csv",
             mode: 'copy'
  publishDir "${params.outdir}/pangolin",
             pattern: ".command.log",
             saveAs: { "pangolin-${input}.log" },
             mode: 'copy'

  input:
  path(input)

  output:
  path '*-pangolin-lineage_report.csv'
  path '.command.log'

  script:
  """
  pangolin \\
    $input \\
    -t ${task.cpus} \\
    --verbose \\
    --outfile ${input}-pangolin-lineage_report.csv
  """
}


workflow {
  Channel.fromPath(params.input) | PANGOLIN
}
```

`nextflow.config` workflow config:

```nextflow
process {
  withName: PANGOLIN {
    // using locally build pangolin container built with:
    // $ DOCKER_BUILDKIT=1 docker build -t covlineages/pangolin .
    // Otherwise, it should auto-pull from Docker Hub
    container = 'covlineages/pangolin'
    // It would be better to specify the exact version of pangolin desired, e.g.
    // container = 'covlineages/pangolin:2.1.2'
    cpus = 4
  }
}

profiles {
  docker {
    docker.enabled = true
    docker.runOptions = '-u \$(id -u):\$(id -g)'
  }
  singularity {
    singularity.enabled = true
    singularity.autoMounts = true
  }
}
```