### PR TITLE
Write decompressed model and header to tempdir to avoid readonly problem

### DIFF
--- a/pangolin/command.py
+++ b/pangolin/command.py
@@ -249,8 +249,10 @@ you must have files ending in putative.fasta.treefile\nExiting.""")
                 if os.path.getsize(trained_model) <= config["compressed_model_size"] + 10:
                     print("Decompressing model and header files")
                     model = joblib.load(trained_model)
-                    joblib.dump(model, trained_model, compress=0)
                     headers = joblib.load(header_file)
+                    trained_model = os.path.join(tempdir, os.path.basename(trained_model))
+                    header_file = os.path.join(tempdir, os.path.basename(header_file))
+                    joblib.dump(model, trained_model, compress=0)
                     joblib.dump(headers, header_file, compress=0)
 
             print("\nData files found")


### PR DESCRIPTION
We install pangonlin inside a singularity image therefore the installation location is readonly. This is also true for system-wide installation. Therefore I changed location of writing out the decompressed header and model files to under tempdir. Without this, pangolin failed with the following error:
![image](https://user-images.githubusercontent.com/447942/105185252-961d6a00-5b30-11eb-8789-d6d64429f2ec.png)
