### PR TITLE
Run quicker for small number of sequences

### DIFF
--- a/pangolin/scripts/pangolearn.py
+++ b/pangolin/scripts/pangolearn.py
@@ -116,7 +116,7 @@ referenceSeq = findReferenceSeq()
 # possible nucleotide symbols
 categories = ['-','A', 'C', 'G', 'T']
 columns = [f"{i}_{c}" for i in indiciesToKeep for c in categories]
-refRow = {f"{i}_{c}": 1 for i,c in zip(indiciesToKeep, encodeSeq(referenceSeq, indiciesToKeep))}
+refRow = [r==c for r in encodeSeq(referenceSeq, indiciesToKeep) for c in categories]
 
 print("loading model " + datetime.now().strftime("%m/%d/%Y, %H:%M:%S"))
 loaded_model = joblib.load(args.model_file)
@@ -129,7 +129,7 @@ for idList, seqList in readInAndFormatData(args.sequences_file, indiciesToKeep):
 		len(seqList), datetime.now().strftime("%m/%d/%Y, %H:%M:%S")
 	))
 
-	rows = [{f"{i}_{c}": 1 for i,c in zip(indiciesToKeep, row)} for row in seqList]
+	rows = [[r==c for r in row for c in categories] for row in seqList]
 	# the reference seq must be added to everry block to make sure that the 
 	# spots in the reference have Ns are in the dataframe to guarentee that 
 	# the correct number of columns is created when get_dummies is called
@@ -137,9 +137,7 @@ for idList, seqList in readInAndFormatData(args.sequences_file, indiciesToKeep):
 	idList.append(referenceId)
 
 	# create a data from from the seqList
-	df = pd.DataFrame.from_records(rows, columns=columns)
-	df.fillna(0, inplace=True)
-	df = df.astype('uint8')
+	df = pd.DataFrame(rows, columns=columns).astype('uint8')
 
 	predictions = loaded_model.predict_proba(df)
 

--- a/pangolin/scripts/pangolearn.py
+++ b/pangolin/scripts/pangolearn.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import pandas as pd
+import numpy as np
 from sklearn.model_selection import train_test_split
 from sklearn.linear_model import LogisticRegression
 from sklearn import metrics
@@ -137,7 +138,8 @@ for idList, seqList in readInAndFormatData(args.sequences_file, indiciesToKeep):
 	idList.append(referenceId)
 
 	# create a data from from the seqList
-	df = pd.DataFrame(rows, columns=columns).astype('uint8')
+	d = np.array(rows, np.uint8)
+	df = pd.DataFrame(d, columns=columns)
 
 	predictions = loaded_model.predict_proba(df)
 

--- a/pangolin/scripts/pangolearn.py
+++ b/pangolin/scripts/pangolearn.py
@@ -13,8 +13,6 @@ import joblib
 import argparse
 import os
 
-import json, sys
-
 def parse_args():
 	parser = argparse.ArgumentParser(description='pangoLEARN.')
 	parser.add_argument("--header-file", action="store", type=str, dest="header_file")
@@ -113,8 +111,6 @@ def readInAndFormatData(sequencesFile, indiciesToKeep, blockSize=1000):
 # loading the list of headers the model needs.
 model_headers = joblib.load(args.header_file)
 indiciesToKeep = model_headers[1:]
-with open("/tmp/model_headers.csv", "w") as f:
-	print("\n".join(map(str,indiciesToKeep)), file=f)
 
 referenceSeq = findReferenceSeq()
 # possible nucleotide symbols


### PR DESCRIPTION
@aunderwo and I have found another way of making pangolin run faster for small inputs.

We've done that by assuming that the one hot encoding will only ever find values in the range `['-','A', 'C', 'G', 'T']`.  I hope that's a good assumption?  I have also marginally sped up the report formatting; the global

This change makes a small difference for medium sized jobs (900 seqs):

`time pangolin --panGUIlin sample.fa`

Before:
```
real    1m28.715s
user    1m26.345s
sys     0m2.716s
```

After:
```
real    1m14.108s
user    1m12.287s
sys     0m2.149s
```

The `lineage_report.csv` before and after are identical.  The `global_lineage_information.csv` is the same but in a different order.

The big difference is if we only run one sequence at a time:

Before:
```
real    0m40.107s
user    0m39.355s
sys     0m1.077s
```

After:
```
real    0m11.236s
user    0m10.563s
sys     0m1.011s
```

All the best,

Ben & Anthony

PS I also ran a large test on 18k COG samples:

Before:
```
real    23m49.850s
user    23m33.926s
sys     0m16.083s
```

After:
```
real    18m27.754s
user    18m15.452s
sys     0m12.552s
```
