### PR TITLE
Add a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/build
+/dist
+/pangolin.egg-info
+__pycache__
+.envrc

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 /build
 /dist
 /pangolin.egg-info
+/logs
 __pycache__
+/*.csv
+/*.fasta
 .envrc
+.vscode


### PR DESCRIPTION
After running setup, I noticed that quite a lot of files are created (eg in the `dist` and `build` folders) that then show up when using git. This change will make sure that [git ignores](https://git-scm.com/docs/gitignore) those files, which (for me at least) makes it easier to find real changes, and less likely that build files will get uploaded to GitHub by accident.

No worries if it's not wanted, but I thought it'd be worth suggesting.