### PR TITLE
Adding UShER as alternative inference engine with new options --usher / --usher-tree

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - python>=3.7
   - snakemake-minimal>=5.13
   - gofasta
+  - usher
   - pip:
     - pandas==1.0.1
     - git+https://github.com/cov-lineages/pangoLEARN.git

--- a/pangolin/command.py
+++ b/pangolin/command.py
@@ -48,6 +48,8 @@ def main(sysargs = sys.argv[1:]):
     parser.add_argument('--tempdir',action="store",help="Specify where you want the temp stuff to go. Default: $TMPDIR")
     parser.add_argument("--no-temp",action="store_true",help="Output all intermediate files, for dev purposes.")
     parser.add_argument('--decompress-model',action="store_true",dest="decompress",help="Permanently decompress the model file to save time running pangolin.")
+    parser.add_argument('--usher', action="store_true",help="Use UShER model instead of default pangoLEARN")
+    parser.add_argument('--usher-tree', action='store', dest='usher_protobuf', help="UShER Mutation Annotated Tree protobuf file to use instead of --usher default from pangoLEARN repository or --datadir")
     parser.add_argument('--max-ambig', action="store", default=0.5, type=float,help="Maximum proportion of Ns allowed for pangolin to attempt assignment. Default: 0.5",dest="maxambig")
     parser.add_argument('--min-length', action="store", default=10000, type=int,help="Minimum query length allowed for pangolin to attempt assignment. Default: 10000",dest="minlen")
     parser.add_argument('--panGUIlin', action='store_true',help="Run web-app version of pangolin",dest="panGUIlin")
@@ -225,6 +227,15 @@ def main(sysargs = sys.argv[1:]):
     trained_model = ""
     header_file = ""
     lineages_csv = ""
+    use_usher = args.usher
+    if args.usher_protobuf:
+        usher_protobuf = os.path.join(cwd, args.usher_protobuf)
+        if not os.path.exists(usher_protobuf):
+            sys.stderr.write('Error: cannot find --usher-tree file at {}\n'.format(usher_protobuf))
+            sys.exit(-1)
+        use_usher = True
+    else:
+        usher_protobuf = ""
 
     for r,d,f in os.walk(data_dir):
         for fn in f:
@@ -234,7 +245,10 @@ def main(sysargs = sys.argv[1:]):
                 trained_model = os.path.join(r, fn)
             elif fn == "lineages.metadata.csv":
                 lineages_csv = os.path.join(r, fn)
-    if trained_model=="" or header_file==""  or lineages_csv=="":
+            elif fn == "lineageTree.pb" and usher_protobuf == "":
+                usher_protobuf = os.path.join(r, fn)
+    if ((use_usher and usher_protobuf == "") or
+        (not use_usher and (trained_model=="" or header_file==""  or lineages_csv==""))):
         print(pfunk.cyan("""Check your environment, didn't find appropriate files from the pangoLEARN repo.\n Trained model must be installed, please see https://cov-lineages.org/pangolin.html for installation instructions."""))
         exit(1)
     else:
@@ -255,9 +269,14 @@ def main(sysargs = sys.argv[1:]):
                 sys.exit(0)
 
         print(pfunk.green("\nData files found"))
-        print(f"Trained model:\t{trained_model}")
-        print(f"Header file:\t{header_file}")
-        print(f"Lineages csv:\t{lineages_csv}")
+        if use_usher:
+            print(f"UShER tree:\t{usher_protobuf}")
+            if args.threads:
+                config["threads"] = args.threads
+        else:
+            print(f"Trained model:\t{trained_model}")
+            print(f"Header file:\t{header_file}")
+            print(f"Lineages csv:\t{lineages_csv}")
         config["trained_model"] = trained_model
         config["header_file"] = header_file
 
@@ -283,6 +302,8 @@ def main(sysargs = sys.argv[1:]):
     if args.panGUIlin:
         config["lineages_csv"]=lineages_csv
 
+    if use_usher:
+        config["usher_protobuf"] = usher_protobuf
 
     if args.verbose:
         quiet_mode = False


### PR DESCRIPTION
This adds usher to environment.yml.  If the new options --usher / --usher-tree are not used then pangolin operates the same as before.

If --usher-tree <file> is given then pangolin will use usher with the specified protobuf file to assign lineages.
If only --usher is added then pangolin expects to find {data_dir}/lineageTree.pb (alongside the usual pangoLEARN files).

If --threads is added then it will be passed along to usher, but I did not remove the message about --threads being ignored.