### PR TITLE
Count ambiguous(missing) alleles separated from other alleles

### DIFF
--- a/pangolin/scripts/pangolearn.smk
+++ b/pangolin/scripts/pangolearn.smk
@@ -4,7 +4,7 @@ import csv
 from Bio import SeqIO
 import os
 import pangofunks as pfunk
-
+from collections import Counter
 ##### Configuration #####
 
 if config.get("trained_model"):
@@ -210,31 +210,36 @@ rule overwrite:
             reader = csv.DictReader(f)
             for row in reader:
                 if int(row["alt_count"]) > 4 and int(row["ref_count"])<6:
-                    b117[row["query"]] = {'alt':row["alt_count"], 'ref':row["ref_count"], 'oth':row["other_count"]}
+                    missing = Counter(row.values())["X"]
+                    b117[row["query"]] = {'alt':row["alt_count"], 'ref':row["ref_count"], 'miss':missing, 'oth':int(row["other_count"])-missing}
         b1351 = {}
         with open(input.b1351_variants, "r") as f:
             reader = csv.DictReader(f)
             for row in reader:
                 if int(row["alt_count"]) > 4 and int(row["ref_count"])<2:
-                    b1351[row["query"]] = {'alt':row["alt_count"], 'ref':row["ref_count"], 'oth':row["other_count"]}
+                    missing = Counter(row.values())["X"]
+                    b1351[row["query"]] = {'alt':row["alt_count"], 'ref':row["ref_count"], 'miss':missing, 'oth':int(row["other_count"])-missing}
         p1 = {}
         with open(input.p1_variants, "r") as f:
             reader = csv.DictReader(f)
             for row in reader:
                 if int(row["alt_count"]) > 10:
-                    p1[row["query"]] = {'alt':row["alt_count"], 'ref':row["ref_count"], 'oth':row["other_count"]}
+                    missing = Counter(row.values())["X"]
+                    p1[row["query"]] = {'alt':row["alt_count"], 'ref':row["ref_count"], 'miss':missing, 'oth':int(row["other_count"])-missing}
         p2 = {}
         with open(input.p2_variants, "r") as f:
             reader = csv.DictReader(f)
             for row in reader:
                 if int(row["alt_count"]) > 4 and int(row["ref_count"])<4:
-                    p2[row["query"]] = {'alt':row["alt_count"], 'ref':row["ref_count"], 'oth':row["other_count"]}
+                    missing = Counter(row.values())["X"]
+                    p2[row["query"]] = {'alt':row["alt_count"], 'ref':row["ref_count"], 'miss':missing, 'oth':int(row["other_count"])-missing}
         p3 = {}
         with open(input.p3_variants, "r") as f:
             reader = csv.DictReader(f)
             for row in reader:
                 if int(row["alt_count"]) > 8 and int(row["ref_count"])<4:
-                    p3[row["query"]] = {'alt':row["alt_count"], 'ref':row["ref_count"], 'oth':row["other_count"]}
+                    missing = Counter(row.values())["X"]
+                    p3[row["query"]] = {'alt':row["alt_count"], 'ref':row["ref_count"], 'miss':missing, 'oth':int(row["other_count"])-missing}
 
         with open(output.csv, "w") as fw:
             # "taxon,lineage,probability,pangoLEARN_version,status,note" 
@@ -257,7 +262,7 @@ rule overwrite:
                         new_row = row
                         
                         snps = b117[row["taxon"]]
-                        note = f'{snps["alt"]}/17 B.1.1.7 SNPs ({snps["ref"]} ref and {snps["oth"]} other)'
+                        note = f'{snps["alt"]}/17 B.1.1.7 SNPs ({snps["ref"]} ref; {snps["oth"]} other; {snps["miss"]} missing)'
 
                         new_row["note"] = note
                         new_row["conflict"] = "0"
@@ -276,7 +281,7 @@ rule overwrite:
                         new_row = row
                         
                         snps = b1351[row["taxon"]]
-                        note = f'{snps["alt"]}/9 B.1.351 SNPs ({snps["ref"]} ref and {snps["oth"]} other)'
+                        note = f'{snps["alt"]}/9 B.1.351 SNPs ({snps["ref"]} ref; {snps["oth"]} other; {snps["miss"]} missing)'
 
                         new_row["note"] = note
                         new_row["conflict"] = "0"
@@ -287,7 +292,7 @@ rule overwrite:
                         new_row = row
                         
                         snps = p2[row["taxon"]]
-                        note = f'{snps["alt"]}/5 P.2 (B.1.1.28.2) SNPs ({snps["ref"]} ref and {snps["oth"]} other)'
+                        note = f'{snps["alt"]}/5 P.2 (B.1.1.28.2) SNPs ({snps["ref"]} ref; {snps["oth"]} other; {snps["miss"]} missing)'
 
                         new_row["note"] = note
                         new_row["conflict"] = "0"
@@ -305,7 +310,7 @@ rule overwrite:
                         new_row = row
                         
                         snps = p1[row["taxon"]]
-                        note = f'{snps["alt"]}/16 P.1 (B.1.1.28.1) SNPs ({snps["ref"]} ref and {snps["oth"]} other)'
+                        note = f'{snps["alt"]}/16 P.1 (B.1.1.28.1) SNPs ({snps["ref"]} ref; {snps["oth"]} other; {snps["miss"]} missing)'
 
                         new_row["note"] = note
                         new_row["conflict"] = "0"
@@ -322,7 +327,7 @@ rule overwrite:
                     elif row["taxon"] in p3:
                         new_row = row
                         snps = p3[row["taxon"]]
-                        note = f'{snps["alt"]}/12 P.3 (B.1.1.28.3) SNPs ({snps["ref"]} ref and {snps["oth"]} other)'
+                        note = f'{snps["alt"]}/12 P.3 (B.1.1.28.3) SNPs ({snps["ref"]} ref; {snps["oth"]} other; {snps["miss"]} missing)'
 
                         new_row["note"] = note
                         new_row["conflict"] = "0"


### PR DESCRIPTION
More details for non-VoC alleles counting, now consist of ref + missing('X') + other as suggested by other users.