### PR TITLE
Corrected sed environment.yml in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN apk update && \
 COPY environment.yml /environment.yml
 # Python 3.8.5 already installed along with recent version of pip
 # so remove Python and pip deps from environment.yml before installation
-RUN sed -i "$(grep -n python>=3.7 /environment.yml | cut -f1 -d:)d" /environment.yml && \
-    sed -i "$(grep -n pip= /environment.yml | cut -f1 -d:)d" /environment.yml
+RUN sed -i "$(grep -n 'python>=3.7' /environment.yml | cut -f1 -d:)d" /environment.yml && \
+    sed -i "$(grep -n 'pip=' /environment.yml | cut -f1 -d:)d" /environment.yml
 # Install the conda environment
 RUN conda env create --quiet -f /environment.yml && conda clean -a
 # Add conda installation dir to PATH (instead of doing 'conda activate')


### PR DESCRIPTION
Hello,

First thank you this great tool.
Then, I wanted to build the v2.4.2 Docker image, and ran into the following issue:

```
Step 6/13 : RUN conda env create --quiet -f /environment.yml && conda clean -a
 ---> Running in c03f11a39392

# >>>>>>>>>>>>>>>>>>>>>> ERROR REPORT <<<<<<<<<<<<<<<<<<<<<<

    Traceback (most recent call last):
      File "/opt/conda/lib/python3.8/site-packages/conda/exceptions.py", line 1079, in __call__
        return func(*args, **kwargs)
      File "/opt/conda/lib/python3.8/site-packages/conda_env/cli/main.py", line 80, in do_call
        exit_code = getattr(module, func_name)(args, parser)
      File "/opt/conda/lib/python3.8/site-packages/conda_env/cli/main_create.py", line 87, in execute
        spec = specs.detect(name=name, filename=filename, directory=os.getcwd())
      File "/opt/conda/lib/python3.8/site-packages/conda_env/specs/__init__.py", line 43, in detect
        if spec.can_handle():
      File "/opt/conda/lib/python3.8/site-packages/conda_env/specs/yaml_file.py", line 18, in can_handle
        self._environment = env.from_file(self.filename)
      File "/opt/conda/lib/python3.8/site-packages/conda_env/env.py", line 160, in from_file
        return from_yaml(yamlstr, filename=filename)
      File "/opt/conda/lib/python3.8/site-packages/conda_env/env.py", line 142, in from_yaml
        data = validate_keys(data, kwargs)
      File "/opt/conda/lib/python3.8/site-packages/conda_env/env.py", line 38, in validate_keys
        for key in data.keys():
    AttributeError: 'NoneType' object has no attribute 'keys'
```

The problem came from the last update of the sed command, which actually deletes the whole content of the environment.yml file: If I am not wrong, `grep -n python>=` actually redirects into the file named '='.

I think the issue is solved using the proposed corrections.

Thank you and best,

Frederic