### PR TITLE
Remove P.1 orf3a:G174C

### DIFF
--- a/pangolin/data/config_p.1.csv
+++ b/pangolin/data/config_p.1.csv
@@ -11,6 +11,5 @@ aa:S:E484K
 aa:S:N501Y
 aa:S:H655Y
 aa:S:T1027I
-aa:orf3a:G174C
 aa:orf8:E92K
 aa:N:P80R


### PR DESCRIPTION
As described in the issue: https://github.com/cov-lineages/pangolin/issues/187

This mutation is not present in the mutations describing P.1 variant ([Table S1](https://science.sciencemag.org/content/sci/suppl/2021/04/13/science.abh2644.DC1/abh2644-Faria-SM.pdf) from [this paper](https://science.sciencemag.org/content/early/2021/04/13/science.abh2644))

This PR removes this mutation, solving the `15/16` issue (which I am also facing).