### PR TITLE
Processing compressed (gz, xz) FASTA inputs

### DIFF
--- a/pangolin/command.py
+++ b/pangolin/command.py
@@ -63,14 +63,16 @@ def main():
     parser.add_argument('--panGUIlin', action='store_true', help="Run web-app version of pangolin",
                         dest="panGUIlin")
     parser.add_argument("--verbose", action="store_true", help="Print lots of stuff to screen")
-    parser.add_argument("-t","--threads", action="store", help="Number of threads")
-    parser.add_argument("-v","--version", action='version', version=f"pangolin {__version__}")
-    parser.add_argument("-pv","--pangoLEARN-version", action='version', version=f"pangoLEARN {pangoLEARN.__version__}",
+    parser.add_argument("-t", "--threads", action="store", help="Number of threads")
+    parser.add_argument("-v", "--version", action='version', version=f"pangolin {__version__}")
+    parser.add_argument("-pv", "--pangoLEARN-version", action='version', version=f"pangoLEARN {pangoLEARN.__version__}",
                         help="show pangoLEARN's version number and exit")
     parser.add_argument("--update", action='store_true', default=False,
                         help="Automatically updates to latest release of pangolin and pangoLEARN, then exits")
-    parser.add_argument("--gzip", action="store_true", help="Query files are gzip-compressed.")
-    parser.add_argument("--xz", action="store_true", help="Query files are xz-compressed.")
+
+    compression = parser.add_mutually_exclusive_group()
+    compression.add_argument("--gzip", action="store_true", help="Query files are gzip-compressed.")
+    compression.add_argument("--xz", action="store_true", help="Query files are xz-compressed.")
 
     if len(sys.argv) == 1:
         parser.print_help()

--- a/pangolin/command.py
+++ b/pangolin/command.py
@@ -27,6 +27,7 @@ import pangofunks as pfunk
 import pkg_resources
 from Bio import SeqIO
 import gzip
+import lzma  # Python 3.3+
 
 from . import _program
 
@@ -69,6 +70,7 @@ def main():
     parser.add_argument("--update", action='store_true', default=False,
                         help="Automatically updates to latest release of pangolin and pangoLEARN, then exits")
     parser.add_argument("--gzip", action="store_true", help="Query files are gzip-compressed.")
+    parser.add_argument("--xz", action="store_true", help="Query files are xz-compressed.")
 
     if len(sys.argv) == 1:
         parser.print_help()
@@ -158,6 +160,8 @@ def main():
     if args.gzip:
         # user says input FASTA file is gzip-compressed, use gzip module to stream text to SeqIO
         query = gzip.open(query, 'rt')  # replace file path (str) with handle
+    if args.xz:
+        query = lzma.open(query, 'rt')
 
     for record in SeqIO.parse(query, "fasta"):
         # replace spaces in sequence headers with underscores


### PR DESCRIPTION
* added mutually-exclusive options `--gzip` and `--xz` to stream FASTA data from gzip or lzma (xz)-compressed files, which can be left in a compressed state in the filesystem
* cleaned up the argparse commands (PEP8 line lengths)
* removed some unused variable assignments, *e.g.*, `sysargs`
* fixed PEP8 code style throughout (line length, whitespace)