### PR TITLE
cyan function errors, changed to colour.cyan

### DIFF
--- a/pangolin/utils/dependency_checks.py
+++ b/pangolin/utils/dependency_checks.py
@@ -42,14 +42,14 @@ def check_dependencies():
 
     if missing:
         if len(missing)==1:
-            sys.stderr.write(cyan(f'Error: Missing dependency `{missing[0]}`.')+'\nPlease update your pangolin environment.\n')
+            sys.stderr.write(colour.cyan(f'Error: Missing dependency `{missing[0]}`.')+'\nPlease update your pangolin environment.\n')
             sys.exit(-1)
         else:
             dependencies = ""
             for i in missing:
                 dependencies+=f"\t- {i}\n"
 
-            sys.stderr.write(cyan(f'Error: Missing dependencies.')+f'\n{dependencies}Please update your pangolin environment.\n')
+            sys.stderr.write(colour.cyan(f'Error: Missing dependencies.')+f'\n{dependencies}Please update your pangolin environment.\n')
             sys.exit(-1)
     else:
         print(colour.green("All dependencies satisfied."))


### PR DESCRIPTION
`dependency_checks.py` calls `cyan` when a dependency check fails, replaced with `colour.cyan`