### PR TITLE
Add scorpio to update and minor update refactor

### DIFF
--- a/pangolin/command.py
+++ b/pangolin/command.py
@@ -30,7 +30,7 @@ except:
 try:
     import constellations
 except:
-    sys.stderr.write(cyan('Error: please install `constellations` dependency with\n`pip install git+git+https://github.com/cov-lineages/constellations.git.\n'))
+    sys.stderr.write(cyan('Error: please install `constellations` dependency with\n`pip install git+https://github.com/cov-lineages/constellations.git.\n'))
     sys.exit(-1)
 
 


### PR DESCRIPTION
- scorpio updated with `--update`

- Refactor update to take a dictionary of dependencies and versions so that `--update-data` and `--update` can use the same function

- Add error handling for a more useful error message when systems have connection issues with `--update` and `--update-data` 

- Fix minor typo in constellations error message
