### PR TITLE
upgrade to usher v0.3.1; add to conflict, note columns

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - python>=3.7
   - snakemake-minimal>=5.13
   - gofasta
-  - usher
+  - usher>=0.3.1
   - pip:
     - pandas==1.0.1
     - git+https://github.com/cov-lineages/pangoLEARN.git

--- a/pangolin/scripts/pangolearn.smk
+++ b/pangolin/scripts/pangolearn.smk
@@ -212,7 +212,7 @@ rule use_usher:
         echo "Using UShER as inference engine."
         if [ -s {input.fasta:q} ]; then
             faToVcf <(cat {input.reference:q} <(echo "") {input.fasta:q}) {params.vcf:q}
-            usher -i {input.usher_protobuf:q} -v {params.vcf:q} -T {workflow.cores} -d '{config[tempdir]}' &> {log}
+            usher -n -D -i {input.usher_protobuf:q} -v {params.vcf:q} -T {workflow.cores} -d '{config[tempdir]}' &> {log}
         else
             touch {output.txt:q}
         fi


### PR DESCRIPTION
usher v0.3.1 is now available in bioconda and has two new options that help with assigning lineages:
* --no-add/-n prevents sequences from being added to the tree after placement, so the structure of the tree read in from lineageTree.pb remains unchanged; this allows a more aggressively pruned tree to be used without being adversely affected by "noisy" sequences adding long branches to it.
* --detailed-clades/-D extends the format of clades.txt to include not only the assigned lineage but also, when there are multiple equally parsimonious placements, each lineage associated with a placement and how many placements were associated with that lineage.  

This PR invokes usher with the new options, so it requires usher>=0.3.1 in environment.yml (previously no version was specified) so most likely an environment update (or reinstall in finicky installations) will be necessary.

Using the extended clades.txt output, the conflict column for PUSHER contains the proportion of placement lineages that disagree with the assigned lineage (in most cases there is only one assigned lineage and conflict is 0).  The note column includes all placement lineages and their placement counts.