### PR TITLE
Don't run faToVcf/usher on empty input (issue #234).

### DIFF
--- a/pangolin/scripts/pangolearn.smk
+++ b/pangolin/scripts/pangolearn.smk
@@ -211,8 +211,12 @@ rule use_usher:
     shell:
         """
         echo "Using UShER as inference engine."
-        faToVcf <(cat {input.reference:q} <(echo "") {input.fasta:q}) {params.vcf:q}
-        usher -i {input.usher_protobuf:q} -v {params.vcf:q} -T {workflow.cores} -d '{config[tempdir]}' &> {log}
+        if [ -s {input.fasta:q} ]; then
+            faToVcf <(cat {input.reference:q} <(echo "") {input.fasta:q}) {params.vcf:q}
+            usher -i {input.usher_protobuf:q} -v {params.vcf:q} -T {workflow.cores} -d '{config[tempdir]}' &> {log}
+        else
+            touch {output.txt:q}
+        fi
         """
 
 rule usher_to_report:


### PR DESCRIPTION
When all input sequences are assigned by PANGO hash and not_assigned.fasta is empty, don't run faToVcf and usher because faToVcf will error out if it's given only the reference genome and no others.  Instead, create an empty clades.txt file for the next step (usher_to_report).
