### PR TITLE
Ensure empty clades.txt is truly empty

### DIFF
--- a/pangolin/scripts/pangolearn.smk
+++ b/pangolin/scripts/pangolearn.smk
@@ -214,6 +214,7 @@ rule use_usher:
             faToVcf <(cat {input.reference:q} <(echo "") {input.fasta:q}) {params.vcf:q}
             usher -i {input.usher_protobuf:q} -v {params.vcf:q} -T {workflow.cores} -d '{config[tempdir]}' &> {log}
         else
+            rm -f {output.txt:q}
             touch {output.txt:q}
         fi
         """


### PR DESCRIPTION
In case of empty input to usher, ensure output is really empty (not retained from previous --no-temp run) by removing old output if present before using touch to create empty output.