### PR TITLE
Add designation dependancy and overwrite lineage with scorpio call unless scorpio call is parent of lineage

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,9 +10,11 @@ dependencies:
   - python>=3.7
   - snakemake-minimal>=5.13
   - gofasta
-  - usher>=0.3.1
+  - usher
   - pip:
     - pandas==1.0.1
     - git+https://github.com/cov-lineages/pangoLEARN.git
     - git+https://github.com/cov-lineages/scorpio.git
     - git+https://github.com/cov-lineages/constellations.git
+    - git+https://github.com/cov-lineages/pango-designation.git
+

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - biopython=1.74
+  - biopython>=1.74
   - minimap2>=2.16
   - pip=19.3.1
   - python>=3.7

--- a/environment.yml
+++ b/environment.yml
@@ -4,13 +4,13 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - biopython>=1.74
+  - biopython=1.74
   - minimap2>=2.16
   - pip=19.3.1
   - python>=3.7
   - snakemake-minimal>=5.13
   - gofasta
-  - usher
+  - usher>=0.3.1
   - pip:
     - pandas==1.0.1
     - git+https://github.com/cov-lineages/pangoLEARN.git

--- a/pangolin/command.py
+++ b/pangolin/command.py
@@ -45,13 +45,6 @@ except:
     "pip install git+https://github.com/cov-lineages/constellations.git")
     sys.exit(-1)
 
-try:
-    import pango_designation
-except:
-    sys.stderr.write(cyan('Error: please install `pango_designation` with \n') +
-    "pip install git+https://github.com/cov-lineages/pango-designation.git")
-    sys.exit(-1)
-
 
 from pangolin.utils import dependency_checks
 from pangolin.utils import data_install_checks
@@ -89,7 +82,7 @@ def main(sysargs = sys.argv[1:]):
     parser.add_argument("-v","--version", action='version', version=f"pangolin {__version__}")
     parser.add_argument("-pv","--pangoLEARN-version", action='version', version=f"pangoLEARN {pangoLEARN.__version__}",help="show pangoLEARN's version number and exit")
     parser.add_argument("-dv","--pango-designation-version", action='version', version=f"pango-designation {PANGO_VERSION}",help="show pango-designation version number and exit")
-    parser.add_argument("--aliases", action='store_true', default=False, help="show pango-designation alias_key.json")
+    parser.add_argument("--aliases", action='store_true', default=False, help="print pango-designation alias_key.json and exit")
     parser.add_argument("--update", action='store_true', default=False, help="Automatically updates to latest release of pangolin, pangoLEARN and constellations, then exits")
     parser.add_argument("--update-data", action='store_true',dest="update_data", default=False, help="Automatically updates to latest release of pangoLEARN and constellations, then exits")
 

--- a/pangolin/command.py
+++ b/pangolin/command.py
@@ -24,6 +24,7 @@ except:
     sys.stderr.write(cyan('Error: please install `pangoLEARN` with \n') + 
     "pip install git+https://github.com/cov-lineages/pangoLEARN.git")
     sys.exit(-1)
+
 try:
     import scorpio
 except:
@@ -42,6 +43,13 @@ try:
 except:
     sys.stderr.write(cyan('Error: please install `constellations` with \n') + 
     "pip install git+https://github.com/cov-lineages/constellations.git")
+    sys.exit(-1)
+
+try:
+    import pango_designation
+except:
+    sys.stderr.write(cyan('Error: please install `pango_designation` with \n') +
+    "pip install git+https://github.com/cov-lineages/pango-designation.git")
     sys.exit(-1)
 
 
@@ -81,6 +89,7 @@ def main(sysargs = sys.argv[1:]):
     parser.add_argument("-v","--version", action='version', version=f"pangolin {__version__}")
     parser.add_argument("-pv","--pangoLEARN-version", action='version', version=f"pangoLEARN {pangoLEARN.__version__}",help="show pangoLEARN's version number and exit")
     parser.add_argument("-dv","--pango-designation-version", action='version', version=f"pango-designation {PANGO_VERSION}",help="show pango-designation version number and exit")
+    parser.add_argument("--aliases", action='store_true', default=False, help="show pango-designation alias_key.json")
     parser.add_argument("--update", action='store_true', default=False, help="Automatically updates to latest release of pangolin, pangoLEARN and constellations, then exits")
     parser.add_argument("--update-data", action='store_true',dest="update_data", default=False, help="Automatically updates to latest release of pangoLEARN and constellations, then exits")
 
@@ -95,12 +104,26 @@ def main(sysargs = sys.argv[1:]):
         update({'pangolin': __version__,
                 'pangolearn': pangoLEARN.__version__,
                 'constellations': constellations.__version__,
-                'scorpio': scorpio.__version__})
+                'scorpio': scorpio.__version__,
+                'pango-designation': pango_designation.__version__
+                })
 
     if args.update_data:
         update({'pangolearn': pangoLEARN.__version__,
-                'constellations': constellations.__version__})
+                'constellations': constellations.__version__,
+                'pango-designation': pango_designation.__version__})
 
+    if args.aliases:
+        pango_designation_dir = pango_designation.__path__[0]
+        for r, d, f in os.walk(pango_designation_dir):
+            for fn in f:
+                if fn == "alias_key.json":
+                    aliases = os.path.join(r, fn)
+                    with open(aliases, 'r') as handle:
+                        for line in handle:
+                            print(line.rstrip())
+                    sys.exit(0)
+        sys.exit(-1)
 
     dependency_checks.check_dependencies()
 
@@ -376,7 +399,10 @@ def update(version_dictionary):
     scorpio: string containing the __version__ data for the imported
                        scorpio module
     constellations: string containing the __version__ data for the imported
-                       constellations data module}
+                       constellations data module
+    pango-designation: string containing the __version__ data for the imported
+                       pango_designation data module}
+
     """
     # flag if any element is update if everything is the latest release
     # we want to just continue running
@@ -404,7 +430,7 @@ def update(version_dictionary):
 
         #print(dependency, version, latest_release)
         # to match the tag names add a v to the pangolin internal version
-        if dependency in ['pangolin', 'scorpio']:
+        if dependency in ['pangolin', 'scorpio', 'pango-designation']:
             version = "v" + version
         # to match the tag names for pangoLEARN add data release
         elif dependency == 'pangolearn':
@@ -415,7 +441,7 @@ def update(version_dictionary):
         else:
             raise ValueError("Dependency name for auto-update must be one "
                              "of: 'pangolin', 'pangolearn', scorpio', "
-                             "'constellations'")
+                             "'constellations', 'pango-designation'")
 
         # convert to LooseVersion to have proper ordering of versions
         # this prevents someone using the latest commit/HEAD from being

--- a/pangolin/command.py
+++ b/pangolin/command.py
@@ -112,17 +112,25 @@ def main(sysargs = sys.argv[1:]):
                 'constellations': constellations.__version__,
                 'pango-designation': pango_designation.__version__})
 
-    if args.aliases:
-        pango_designation_dir = pango_designation.__path__[0]
-        for r, d, f in os.walk(pango_designation_dir):
-            for fn in f:
-                if fn == "alias_key.json":
-                    aliases = os.path.join(r, fn)
-                    with open(aliases, 'r') as handle:
-                        for line in handle:
-                            print(line.rstrip())
-                    sys.exit(0)
+    alias_file = None
+    pango_designation_dir = pango_designation.__path__[0]
+    for r, d, f in os.walk(pango_designation_dir):
+        for fn in f:
+            if fn == "alias_key.json":
+                alias_file = os.path.join(r, fn)
+    if not alias_file:
+        sys.stderr.write(cyan('Could not find alias file: please update pango-designation with \n') +
+                         "pip install git+https://github.com/cov-lineages/pango-designation.git")
         sys.exit(-1)
+
+    if args.aliases:
+        with open(alias_file, 'r') as handle:
+            for line in handle:
+                print(line.rstrip())
+        sys.exit(0)
+
+
+
 
     dependency_checks.check_dependencies()
 
@@ -260,6 +268,7 @@ def main(sysargs = sys.argv[1:]):
         "trim_start":265,   # where to pad to using datafunk
         "trim_end":29674,   # where to pad after using datafunk
         "qc_fail":qc_fail,
+        "alias_file": alias_file,
         "verbose":args.verbose,
         "pangoLEARN_version":pangoLEARN.__version__,
         "pangolin_version":__version__,

--- a/pangolin/command.py
+++ b/pangolin/command.py
@@ -45,6 +45,12 @@ except:
     "pip install git+https://github.com/cov-lineages/constellations.git")
     sys.exit(-1)
 
+try:
+    import pango_designation
+except:
+    sys.stderr.write(cyan('Error: please install `pango_designation` with \n') +
+    "pip install git+https://github.com/cov-lineages/pango-designation.git")
+    sys.exit(-1)
 
 from pangolin.utils import dependency_checks
 from pangolin.utils import data_install_checks


### PR DESCRIPTION
This PR adds pango-designation repository as a dependancy.

- It is updatable using the `--update` and `--update-data` commands
- `--aliases` will print the aliases_key.json to stdout
- update happens before aliases so will first check for latest if specified
- quits after printing aliases
- Has not changed the PANGO_VERSION taken from pangoLEARN because this is the version actually trained on and I can think of possible times when there might be a difference

Secondly this PR overwrites lineage call with a scorpio call unless scorpio call is a parent of lineage call
