### PR TITLE
Add pangolin to environment.yaml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,4 +17,5 @@ dependencies:
     - git+https://github.com/cov-lineages/scorpio.git
     - git+https://github.com/cov-lineages/constellations.git
     - git+https://github.com/cov-lineages/pango-designation.git
+    - git+https://github.com/cov-lineages/pangolin.git
 


### PR DESCRIPTION
The environment file is missing the crucial component. Then people can install without cloning the repo:

```
conda env create -n pangolin_v3 -f https://raw.githubusercontent.com/cov-lineages/pangolin/master/environment.yml
```

Cheers. Anders.