### PR TITLE
Require usher>=0.3.2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - python>=3.7
   - snakemake-minimal>=5.13
   - gofasta
-  - usher
+  - usher>=0.3.2
   - pip:
     - pandas==1.0.1
     - git+https://github.com/cov-lineages/pangoLEARN.git


### PR DESCRIPTION
pangolin --usher uses some usher options that were added in v0.3.2.  An error was reported in #266 when an older version of usher was used with the latest version of pangolin.  Previously there was a problem with the bioconda build for Mac with v0.3.2, but that has been resolved, so I think it's safe to require v0.3.2 now.  