### PR TITLE
Dev

### DIFF
--- a/pangolin/__init__.py
+++ b/pangolin/__init__.py
@@ -1,5 +1,5 @@
 _program = "pangolin"
-__version__ = "3.1.9"
+__version__ = "3.1.10"
 
 
 __all__ = ["pangolearn",

--- a/pangolin/command.py
+++ b/pangolin/command.py
@@ -102,6 +102,7 @@ def main(sysargs = sys.argv[1:]):
     parser.add_argument("-pv","--pangoLEARN-version", action='version', version=f"pangoLEARN {pangoLEARN.__version__}",help="show pangoLEARN's version number and exit")
     parser.add_argument("-dv","--pango-designation-version", action='version', version=f"pango-designation {PANGO_VERSION} used for pangoLEARN and UShER training",help="show pango-designation version number used for training and exit")
     parser.add_argument("--aliases", action='store_true', default=False, help="print pango-designation alias_key.json and exit")
+    parser.add_argument("--skip-designation-hash", action='store_true', default=False, help="Developer option - do not use designation hash to assign lineages")
     parser.add_argument("--update", action='store_true', default=False, help="Automatically updates to latest release of pangolin, pangoLEARN and constellations, then exits")
     parser.add_argument("--update-data", action='store_true',dest="update_data", default=False, help="Automatically updates to latest release of pangoLEARN and constellations, then exits")
 
@@ -319,6 +320,7 @@ def main(sysargs = sys.argv[1:]):
         "qc_fail":qc_fail,
         "alias_file": alias_file,
         "constellation_files": constellation_files,
+        "skip_designation_hash": args.skip_designation_hash,
         "verbose":args.verbose,
         "pangoLEARN_version":pangoLEARN.__version__,
         "pangolin_version":__version__,

--- a/pangolin/scripts/pangolearn.smk
+++ b/pangolin/scripts/pangolearn.smk
@@ -255,12 +255,17 @@ rule generate_report:
                             elif "incompatible_lineages" in scorpio_call_info and row['lineage'] in scorpio_call_info["incompatible_lineages"].split("|"):
                                 new_row["note"] += f'; scorpio replaced lineage assignment {row["lineage"]}'
                                 new_row['lineage'] = scorpio_lineage
-                    elif row['lineage'] in voc_list:
-                        # have no scorpio call but a pangolearn voc/vui call
-                        new_row['note'] += f'pangoLEARN lineage assignment {row["lineage"]} was not supported by scorpio'
-                        new_row['lineage'] = UNASSIGNED_LINEAGE_REPORTED
-                        new_row['conflict'] = ""
-                        new_row['ambiguity_score'] = ""
+                    else:
+                        expanded_pango_lineage = expand_alias(row['lineage'], alias_dict)
+                        while len(expanded_pango_lineage) > 3:
+                            if expanded_pango_lineage in voc_list:
+                                # have no scorpio call but a pangolearn voc/vui call
+                                new_row['note'] += f'pangoLEARN lineage assignment {row["lineage"]} was not supported by scorpio'
+                                new_row['lineage'] = UNASSIGNED_LINEAGE_REPORTED
+                                new_row['conflict'] = ""
+                                new_row['ambiguity_score'] = ""
+                                break
+                            expanded_pango_lineage = ".".join(expanded_pango_lineage.split(".")[:-1])
                     writer.writerow(new_row)
 
         print(green(f"Output file written to: ") + f"{output.csv}")
@@ -394,14 +399,22 @@ rule usher_to_report:
 
                         if histogram_note:
                             note += f'; {histogram_note}'
-                    elif lineage in voc_list:
-                        # have no scorpio call but an usher voc/vui call
-                        note += f'usher lineage assignment {lineage} was not supported by scorpio'
-                        note += f'; {histogram_note}'
-                        lineage = UNASSIGNED_LINEAGE_REPORTED
-                        conflict = ""
                     else:
-                        note = histogram_note
+                        expanded_pango_lineage = expand_alias(lineage, alias_dict)
+                        lineage_unassigned = False
+                        while len(expanded_pango_lineage) > 3:
+                            if expanded_pango_lineage in voc_list:
+                                # have no scorpio call but an usher voc/vui call
+                                note += f'usher lineage assignment {lineage} was not supported by scorpio'
+                                note += f'; {histogram_note}'
+                                lineage = UNASSIGNED_LINEAGE_REPORTED
+                                conflict = ""
+                                lineage_unassigned = True
+                                break
+                            expanded_pango_lineage = ".".join(expanded_pango_lineage.split(".")[:-1])
+
+                        if not lineage_unassigned:
+                            note = histogram_note
                     fw.write(f"{name},{lineage},{conflict},,{scorpio_call},{scorpio_support},{scorpio_conflict},{version},{config['pangolin_version']},,{config['pango_version']},passed_qc,{note}\n")
                     passed.append(name)
 

--- a/pangolin/scripts/pangolearn.smk
+++ b/pangolin/scripts/pangolearn.smk
@@ -80,6 +80,8 @@ rule hash_sequence_assign:
     output:
         designated = os.path.join(config["tempdir"],"hash_assigned.csv"),
         for_inference = os.path.join(config["tempdir"],"not_assigned.fasta")
+    params:
+        skip_designation_hash = config["skip_designation_hash"]
     run:
         set_hash = {}
         with open(config["designated_hash"],"r") as f:
@@ -93,7 +95,7 @@ rule hash_sequence_assign:
                 for record in SeqIO.parse(input.fasta, "fasta"):
                     if record.id!="reference":
                         hash_string = get_hash_string(record)
-                        if hash_string in set_hash:
+                        if not params.skip_designation_hash and hash_string in set_hash:
                             fw.write(f"{record.id},{set_hash[hash_string]}\n")
                         else:
                             fseq.write(f">{record.description}\n{record.seq}\n")

--- a/pangolin/scripts/pangolearn.smk
+++ b/pangolin/scripts/pangolearn.smk
@@ -257,7 +257,7 @@ rule generate_report:
                                 new_row['lineage'] = scorpio_lineage
                     else:
                         expanded_pango_lineage = expand_alias(row['lineage'], alias_dict)
-                        while len(expanded_pango_lineage) > 3:
+                        while expanded_pango_lineage and len(expanded_pango_lineage) > 3:
                             if expanded_pango_lineage in voc_list:
                                 # have no scorpio call but a pangolearn voc/vui call
                                 new_row['note'] += f'pangoLEARN lineage assignment {row["lineage"]} was not supported by scorpio'
@@ -402,7 +402,7 @@ rule usher_to_report:
                     else:
                         expanded_pango_lineage = expand_alias(lineage, alias_dict)
                         lineage_unassigned = False
-                        while len(expanded_pango_lineage) > 3:
+                        while expanded_pango_lineage and len(expanded_pango_lineage) > 3:
                             if expanded_pango_lineage in voc_list:
                                 # have no scorpio call but an usher voc/vui call
                                 note += f'usher lineage assignment {lineage} was not supported by scorpio'


### PR DESCRIPTION
- Extend the false positive removal so will apply to new AY.x sublineages where the parent is a voc/vui but the lineage itself is not, but we still want to have confirmation from scorpio.
- Add developer option to skip designation hash
