### PR TITLE
Change version variable used in pangolin -dv CLI output

### DIFF
--- a/pangolin/command.py
+++ b/pangolin/command.py
@@ -99,7 +99,7 @@ def main(sysargs = sys.argv[1:]):
     parser.add_argument("-t","--threads",action="store",default=1,type=int, help="Number of threads")
     parser.add_argument("-v","--version", action='version', version=f"pangolin {__version__}")
     parser.add_argument("-pv","--pangoLEARN-version", action='version', version=f"pangoLEARN {pangoLEARN.__version__}",help="show pangoLEARN's version number and exit")
-    parser.add_argument("-dv","--pango-designation-version", action='version', version=f"pango-designation {PANGO_VERSION} used for pangoLEARN and UShER training",help="show pango-designation version number used for training and exit")
+    parser.add_argument("-dv","--pango-designation-version", action='version', version=f"pango-designation {pango_designation.__version__} used for pangoLEARN and UShER training",help="show pango-designation version number used for training and exit")
     parser.add_argument("--aliases", action='store_true', default=False, help="print pango-designation alias_key.json and exit")
     parser.add_argument("--skip-designation-hash", action='store_true', default=False, help="Developer option - do not use designation hash to assign lineages")
     parser.add_argument("--update", action='store_true', default=False, help="Automatically updates to latest release of pangolin, pangoLEARN and constellations, then exits")
@@ -311,7 +311,7 @@ def main(sysargs = sys.argv[1:]):
                     for item in desc:
                         if item.startswith("fail="):
                             reason = item.split("=")[1]
-                    fw.write(f"{record.id},None,,,,,,PANGO-{PANGO_VERSION},{__version__},{pangoLEARN.__version__},{PANGO_VERSION},fail,{reason}\n")
+                    fw.write(f"{record.id},None,,,,,,PANGO-{pango_designation.__version__},{__version__},{pangoLEARN.__version__},{pango_designation.__version__},fail,{reason}\n")
             print(cyan(f'Note: no query sequences have passed the qc\n'))
             sys.exit(0)
 
@@ -338,7 +338,7 @@ def main(sysargs = sys.argv[1:]):
             "verbose":args.verbose,
             "pangoLEARN_version":pangoLEARN.__version__,
             "pangolin_version":__version__,
-            "pango_version":PANGO_VERSION,
+            "pango_version":pango_designation.__version__,
             "threads":args.threads
             }
 


### PR DESCRIPTION
The current pangolin imports the pango_designation version "1.2.56" from pangoLEARN as a variable called PANGO_VERSION, presumably as a method of ensuring that minimum viable versions of pango designation and pangoLEARN models are used with the current pangolin version. 

However, this causes discrepancies when using either pangolin --all-versions or pangolin -dv on Terminal. Since PANGO_VERSION is used in the console printout, the CLI output may report 1.2.56 as the pango designation version being used, when in fact an update using pangolin --update will change the actual version used (i.e. 1.2.64). 

A simple reassignment of the pango designation variable output in this PR ensures that the pango designation version is the same between CLI output(s) and the actual report. 

Should also be able to close #300. 