### PR TITLE
Enable pangolin to read from stdin

### DIFF
--- a/pangolin/command.py
+++ b/pangolin/command.py
@@ -271,8 +271,8 @@ def main(sysargs = sys.argv[1:]):
     3) write a file that contains just the seqs to run
     """
     if not args.decompress:
-        do_not_run = []
-        run = []
+        # do_not_run = []
+        # run = []
         
         print(green("** Running sequence QC **"))
 
@@ -314,7 +314,8 @@ def main(sysargs = sys.argv[1:]):
                         fw_pass.write(f">{record.description}\n{seq}\n")
         except UnicodeDecodeError:
             sys.stderr.write(cyan(
-                f'Error: input query fasta could not be detected from a filepath or through stdin.\n' +
+                f'Error: the input query fasta could not be parsed.\n' +
+                'Double check your query fasta and that compressed stdin was not passed.\n' +
                 'Please enter your fasta sequence file and refer to pangolin usage at: https://cov-lineages.org/pangolin.html' +
                 ' for detailed instructions.\n'))
             sys.exit(-1)


### PR DESCRIPTION
This aims to resolve #329. 

pangolin can now read in stdin from a bash pipe with "-", as requested in #329. If no query fasta or stdin is specified, such as : 
`pangolin --outfile lineage_report.csv`
pangolin will output: 
`Error: input query fasta could not be detected from a filepath or through stdin.
Please enter your fasta sequence file and refer to pangolin usage at: https://cov-lineages.org/pangolin.html for detailed instructions.`

If "-" is used to designate stdin, but there is no stdin for pangolin to use, i.e. if nothing is piped into the pangolin command: 
`pangolin --outfile lineage_report.csv -`

it will output: 
`Error: cannot find query (input) fasta file using stdin.
Please enter your fasta sequence file and refer to pangolin usage at: https://cov-lineages.org/pangolin.html for detailed instructions.`

The methods for dealing with file paths that do not exist remain the same as before. 

If the user attempts to pass a compressed stdin, such as: 
`cat test.fa | gzip | pangolin --outfile lineage_report.csv -`

pangolin will report: 

`Error: error when reading query fasta.
It is possible that compressed stdin was passed.`

A important note that is this error message above will be thrown if any of the inputs (compressed or not) cannot ultimately be read as a FASTA file by SeqIO. This may want to be changed in the future but I tried my best to allow pangolin to differentiate between stdin and filepaths and the compression status of either input. 
