### PR TITLE
remove false positive B.1.1.7 call #342

### DIFF
--- a/pangolin/scripts/pangolearn.smk
+++ b/pangolin/scripts/pangolearn.smk
@@ -261,7 +261,7 @@ rule generate_report:
                         expanded_pango_lineage = expand_alias(row['lineage'], alias_dict)
                         while expanded_pango_lineage and len(expanded_pango_lineage) > 3:
                             for voc in voc_list:
-                                if expanded_pango_lineage.startswith(voc + "."):
+                                if expanded_pango_lineage.startswith(voc):
                                     # have no scorpio call but a pangolearn voc/vui call
                                     new_row['note'] += f'pangoLEARN lineage assignment {row["lineage"]} was not supported by scorpio'
                                     new_row['lineage'] = UNASSIGNED_LINEAGE_REPORTED
@@ -409,7 +409,7 @@ rule usher_to_report:
                         lineage_unassigned = False
                         while expanded_pango_lineage and len(expanded_pango_lineage) > 3:
                             for voc in voc_list:
-                                if expanded_pango_lineage.startswith(voc + "."):
+                                if expanded_pango_lineage.startswith(voc):
                                     # have no scorpio call but an usher voc/vui call
                                     note += f'usher lineage assignment {lineage} was not supported by scorpio'
                                     note += f'; {histogram_note}'

--- a/pangolin/scripts/pangolearn.smk
+++ b/pangolin/scripts/pangolearn.smk
@@ -261,7 +261,7 @@ rule generate_report:
                         expanded_pango_lineage = expand_alias(row['lineage'], alias_dict)
                         while expanded_pango_lineage and len(expanded_pango_lineage) > 3:
                             for voc in voc_list:
-                                if expanded_pango_lineage.startswith(voc):
+                                if expanded_pango_lineage.startswith(voc + ".") or expanded_pango_lineage == voc:
                                     # have no scorpio call but a pangolearn voc/vui call
                                     new_row['note'] += f'pangoLEARN lineage assignment {row["lineage"]} was not supported by scorpio'
                                     new_row['lineage'] = UNASSIGNED_LINEAGE_REPORTED
@@ -409,7 +409,7 @@ rule usher_to_report:
                         lineage_unassigned = False
                         while expanded_pango_lineage and len(expanded_pango_lineage) > 3:
                             for voc in voc_list:
-                                if expanded_pango_lineage.startswith(voc):
+                                if expanded_pango_lineage.startswith(voc + ".") or expanded_pango_lineage == voc :
                                     # have no scorpio call but an usher voc/vui call
                                     note += f'usher lineage assignment {lineage} was not supported by scorpio'
                                     note += f'; {histogram_note}'


### PR DESCRIPTION
The presence of the "." in the comparison meant that straight B.1.1.7 false positives were not being removed.