### PR TITLE
Handle none scorpio mrca lineage

### DIFF
--- a/pangolin/__init__.py
+++ b/pangolin/__init__.py
@@ -1,5 +1,5 @@
 _program = "pangolin"
-__version__ = "3.1.17"
+__version__ = "3.1.18"
 
 
 __all__ = ["pangolearn",

--- a/pangolin/scripts/pangolearn.smk
+++ b/pangolin/scripts/pangolearn.smk
@@ -257,6 +257,9 @@ rule generate_report:
                             elif "incompatible_lineages" in scorpio_call_info and row['lineage'] in scorpio_call_info["incompatible_lineages"].split("|"):
                                 new_row["note"] += f'; scorpio replaced lineage assignment {row["lineage"]}'
                                 new_row['lineage'] = scorpio_lineage
+                            elif not expanded_scorpio_lineage:
+                                new_row["note"] += f'; scorpio replaced lineage assignment {row["lineage"]}'
+                                new_row['lineage'] = UNASSIGNED_LINEAGE_REPORTED
                     else:
                         expanded_pango_lineage = expand_alias(row['lineage'], alias_dict)
                         while expanded_pango_lineage and len(expanded_pango_lineage) > 3:
@@ -401,6 +404,9 @@ rule usher_to_report:
                         elif "incompatible_lineages" in scorpio_call_info and lineage in scorpio_call_info["incompatible_lineages"].split("|"):
                             note += f'; scorpio replaced lineage assignment {lineage}'
                             lineage = scorpio_lineage
+                        elif not expanded_scorpio_lineage:
+                                note += f'; scorpio replaced lineage assignment {row["lineage"]}'
+                                lineage = UNASSIGNED_LINEAGE_REPORTED
 
                         if histogram_note:
                             note += f'; {histogram_note}'


### PR DESCRIPTION
The lineage call B.1.1.529 is misleading as there are no designated sequences for this label and is usually instead indicates lower quality/contaminated sequences that could not be well assigned. We want to remove it as a possibility. This change handles the case where the constellation file has `mrca_lineage`:"None" and allows this to override a lineage call.