### PR TITLE
Use faToVcf's -includeNoAltN option (requires updated bioconda ucsc-fatovcf)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - snakemake-minimal<=6.8.0
   - gofasta
   - pysam==0.16.0.1
+  - ucsc-fatovcf>=426
   - usher>=0.3.2
   - pip:
     - git+https://github.com/cov-lineages/pangoLEARN.git

--- a/pangolin/scripts/pangolearn.smk
+++ b/pangolin/scripts/pangolearn.smk
@@ -298,7 +298,7 @@ rule use_usher:
         """
         echo "Using UShER as inference engine."
         if [ -s {input.fasta:q} ]; then
-            faToVcf <(cat {input.reference:q} <(echo "") {input.fasta:q}) {params.vcf:q}
+            faToVcf -includeNoAltN <(cat {input.reference:q} <(echo "") {input.fasta:q}) {params.vcf:q}
             usher -n -D -i {input.usher_protobuf:q} -v {params.vcf:q} -T {workflow.cores} -d '{config[tempdir]}' &> {log}
         else
             rm -f {output.txt:q}


### PR DESCRIPTION
This updates the `faToVcf` command in usher mode to use the `-includeNoAltN` option so that usher knows where a sequence has N (as opposed to assuming it has the reference allele) -- important for accuracy, especially when running on a small number of sequences.

We should have been using this option since last June when it was added in UCSC source code, but clumsy build config in the UCSC source tree caused conda build problems, so the bioconda package ucsc-fatovcf had not been updated since last March.  That has finally been resolved, and the latest bioconda ucsc-fatovcf package (version 426) supports `-includeNoAltN`.

Unfortunately, everyone probably has the old ucsc-fatovcf version (407) installed that does not support `-includeNoAltN`, so `pangolin --usher` will error out unless ucsc-fatovcf is updated.  I added `ucsc-fatovcf>=426` to environment.yml so I think there will be two ways for people to update ucsc-fatovcf:

* `conda env update -n pangolin -f environment.yml`
* `conda activate pangolin && conda update ucsc-fatovcf`.

It will be even more important to use `-includeNoAltN` in pangolin v4.0 when usher is the default mode.