### PR TITLE
fix #383: de-indent else clause that overwrites w/Unassigned

### DIFF
--- a/pangolin/utils/report_collation.py
+++ b/pangolin/utils/report_collation.py
@@ -268,9 +268,7 @@ def generate_final_report(preprocessing_csv, inference_csv, cached_csv, alias_fi
 
                             expanded_pango_lineage = ".".join(expanded_pango_lineage.split(".")[:-1])
 
-                    else:
-                        new_row["lineage"] = UNASSIGNED_LINEAGE_REPORTED
-
-                
+                else:
+                    new_row["lineage"] = UNASSIGNED_LINEAGE_REPORTED
 
                 writer.writerow(new_row)


### PR DESCRIPTION
The final else clause in generate_final_report needed to be de-indented after the last change (#380 / #381); it was causing lineages to be overwritten with Unassigned unless they were designated or scorpio-assigned.

fixes #383
