### PR TITLE
Minimal checking of results in github actions test

### DIFF
--- a/.github/workflows/pangolin.yml
+++ b/.github/workflows/pangolin.yml
@@ -25,6 +25,8 @@ jobs:
         run: pangolin --version
       - name: Run pangolin with test data
         run: pangolin pangolin/test/test_seqs.fasta 2>&1 | tee pangolin.log
+      - name: Compare assigned lineages (first two columns only) with expected values
+        run: cut -d, -f1,2 lineage_report.csv | diff - pangolin/test/test_seqs.assignments.csv
       - name: Run pangolin with test zip data
         run: pangolin pangolin/test/test_seqs.fasta.gz 2>&1 | tee pangolin_zip.log
       - name: Run pangolin with test all cache data

--- a/pangolin/test/test_seqs.assignments.csv
+++ b/pangolin/test/test_seqs.assignments.csv
@@ -1,0 +1,9 @@
+taxon,lineage
+India seq,B.1.617.1
+b117,B.1.1.7
+outgroup_A,A
+This_seq_is_too_short,Unassigned
+This_seq_has_lots_of_Ns,Unassigned
+Japan_seq,B
+USA_seq,B.1.314
+Unassigned_omicron_seq,Unassigned


### PR DESCRIPTION
Currently pangolin.yml and pangolin_macos.yml run pangolin with various options and inputs to make sure that it returns without an error code, but they don't yet check the lineage assignments.  This change adds minimal checking of the lineage assignments after the first test in pangolin.yml: only the first two columns of lineage_report.csv from running `pangolin pangolin/test/test_seqs.fasta`.  The diff command works on the command line, here's hoping it will work the same way in github actions...