### PR TITLE
Updates for --update-data --datadir

### DIFF
--- a/pangolin/command.py
+++ b/pangolin/command.py
@@ -101,6 +101,8 @@ def main(sysargs = sys.argv[1:]):
     if args.usher:
         sys.stderr.write(cyan(f"--usher is a pangolin v3 option and is deprecated in pangolin v4.  UShER is now the default analysis mode.  Use --analysis-mode to explicitly set mode.\n"))
 
+    setup_data(args.datadir,config[KEY_ANALYSIS_MODE], config)
+
     if args.add_assignment_cache:
         update.install_pangolin_assignment()
 
@@ -133,7 +135,6 @@ def main(sysargs = sys.argv[1:]):
     print(green(f"****\nPangolin running in {config[KEY_ANALYSIS_MODE]} mode.\n****"))
     snakefile = get_snakefile(thisdir,config[KEY_ANALYSIS_MODE])
 
-    setup_data(args.datadir,config[KEY_ANALYSIS_MODE], config)
     config[KEY_DESIGNATION_CACHE],config[KEY_ALIAS_FILE] = data_checks.find_designation_cache_and_alias(config[KEY_DATADIR],DESIGNATION_CACHE_FILE,ALIAS_FILE)
     if args.aliases:
         print_alias_file_exit(config[KEY_ALIAS_FILE])

--- a/pangolin/utils/update.py
+++ b/pangolin/utils/update.py
@@ -144,6 +144,8 @@ def update(version_dictionary, data_dir=None):
                     tf.extractall(path=tempdir)
                     tf.close()
                     destination_directory = os.path.join(data_dir, dependency_package)
+                    if os.path.isdir(destination_directory):
+                        shutil.rmtree(destination_directory)
                     shutil.move(os.path.join(tempdir, extracted_dir, dependency_package), destination_directory)
             else:
                 pip_install_dep(dependency, latest_release)


### PR DESCRIPTION
@pvanheus asked about --update-data --datadir so I did a little testing and found a few small changes to be made:
* setup_data needs to be called before --update/--update-data options are processed, so that --datadir versions are used
* when --update-data --datadir is caused multiple times resulting in multiple updates of the same directory, the destination directory needs to be removed if it already exists or strange things happen like the source directory ending up as a subdirectory of the destination directory (and if that happens again, a failure because the subdirectory already exists)
* minor: use LooseVersion in setup_data, same as in update

--datadir is rejected if its pangolin_data version is older than the conda-installed version -- is that new in v4?