### PR TITLE
Add expanded lineage output resolve #261

### DIFF
--- a/pangolin/command.py
+++ b/pangolin/command.py
@@ -98,7 +98,8 @@ def main(sysargs = sys.argv[1:]):
     parser.add_argument("--update", action='store_true', default=False, help="Automatically updates to latest release of pangolin, pangoLEARN and constellations, then exits")
     parser.add_argument("--update-data", action='store_true',dest="update_data", default=False, help="Automatically updates to latest release of pangoLEARN and constellations, then exits")
     parser.add_argument("--all-versions", action='store_true',dest="all_versions", default=False, help="Print all tool, dependency, and data versions then exit.")
-
+    parser.add_argument('--expanded-lineage', action="store_true", default=False, help="Optional expanded lineage from alias.json in report.")
+    
     if len(sysargs)<1:
         parser.print_help()
         sys.exit(-1)
@@ -185,7 +186,6 @@ def main(sysargs = sys.argv[1:]):
               f"pango-designation used by pangoLEARN/Usher: {PANGO_VERSION}\n"
               f"pango-designation aliases: {pango_designation.__version__}")
         sys.exit(0)
-
 
     dependency_checks.check_dependencies(args.usher)
 
@@ -355,7 +355,8 @@ def main(sysargs = sys.argv[1:]):
             "pangoLEARN_version":pangoLEARN.__version__,
             "pangolin_version":__version__,
             "pango_version":PANGO_VERSION,
-            "threads":args.threads
+            "threads":args.threads,
+            "expanded_lineage": args.expanded_lineage,
             }
 
         data_install_checks.check_install(config)


### PR DESCRIPTION
(This is my first attempt to submit a contribution to a public repository. Any feedback would be appreciated)
Resolves issue #261 
This was an old issue brought up by another contributor requesting the inclusion of de-aliased (expanded) lineages in the output reports. I created a new flag argument and implemented a new column on the reports from both pangolearn and usher. I utilized the existing expand_alias function.  For simpler maintenance and readability at a slight cost to speed, I elected to rerun the function just before writing based on the final lineage rather than catching the already calculated expanded lineage at each relevant part of the loop. I also inserted a check for "UNASSIGNED_LINEAGE_REPORTED" rather than change the current implementation of the expand_alias function to handle "UNASSIGNED_LINEAGE_REPORTED" differently. 