### PR TITLE
Add expanded lineage output dev branch resolve #261

### DIFF
--- a/pangolin/command.py
+++ b/pangolin/command.py
@@ -58,6 +58,8 @@ def main(sysargs = sys.argv[1:]):
     io_group.add_argument("--no-temp",action="store_true",help="Output all intermediate files, for dev purposes.")
     io_group.add_argument('--alignment', action="store_true",help="Output multiple sequence alignment.")
     io_group.add_argument('--alignment-file', action="store",help="Multiple sequence alignment file name.")
+    io_group.add_argument('--expanded-lineage', action="store_true", default=False, help="Optional expanded lineage from alias.json in report.")
+
 
     a_group = parser.add_argument_group('Analysis options')
     a_group.add_argument('--analysis-mode', action="store",help="Specify which inference engine to use. Options: accurate (UShER), fast (pangoLEARN), pangolearn, usher. Default: UShER inference.")
@@ -129,7 +131,11 @@ def main(sysargs = sys.argv[1:]):
     if args.skip_scorpio:
         print(green(f"****\nPangolin skipping scorpio steps.\n****"))
         config[KEY_SKIP_SCORPIO] = True
-
+    
+    if args.expanded_lineage:
+        print(green(f"****\nAdding expanded lineage column to output.\n****"))
+        config[KEY_EXPANDED_LINEAGE] = True
+        
     # Parsing analysis mode flags to return one of 'usher' or 'pangolearn'
     config[KEY_ANALYSIS_MODE] = set_up_analysis_mode(args.analysis_mode, config[KEY_ANALYSIS_MODE])
     print(green(f"****\nPangolin running in {config[KEY_ANALYSIS_MODE]} mode.\n****"))

--- a/pangolin/utils/config.py
+++ b/pangolin/utils/config.py
@@ -24,6 +24,8 @@ KEY_ALIAS_FILE="alias_file"
 
 KEY_SKIP_SCORPIO = "skip_scorpio"
 
+KEY_EXPANDED_LINEAGE="expanded_lineage"
+
 KEY_CONSTELLATION_FILES="constellation_files"
 KEY_USHER_PB = "usher_pb"
 KEY_PLEARN_MODEL = "plearn_model"

--- a/pangolin/utils/initialising.py
+++ b/pangolin/utils/initialising.py
@@ -42,6 +42,8 @@ def setup_config_dict(cwd):
 
             KEY_SKIP_SCORPIO: False,
 
+            KEY_EXPANDED_LINEAGE: False,
+
             KEY_CONSTELLATION_FILES: [],
             
             KEY_PANGOLIN_VERSION: __version__,

--- a/pangolin/utils/report_collation.py
+++ b/pangolin/utils/report_collation.py
@@ -192,6 +192,8 @@ def generate_final_report(preprocessing_csv, inference_csv, cached_csv, alias_fi
             reader = csv.DictReader(f)
 
             out_header = FINAL_HEADER
+            if config['expanded_lineage']:
+                out_header.append('expanded_lineage')
             
             writer = csv.DictWriter(fw, fieldnames=out_header, lineterminator="\n")
             writer.writeheader()
@@ -270,5 +272,9 @@ def generate_final_report(preprocessing_csv, inference_csv, cached_csv, alias_fi
 
                 else:
                     new_row["lineage"] = UNASSIGNED_LINEAGE_REPORTED
-
+                if config['expanded_lineage']:
+                    if new_row["lineage"] == UNASSIGNED_LINEAGE_REPORTED:
+                        new_row["expanded_lineage"] = UNASSIGNED_LINEAGE_REPORTED
+                    else:
+                        new_row["expanded_lineage"] = expand_alias(new_row["lineage"], alias_dict)
                 writer.writerow(new_row)


### PR DESCRIPTION
Regarding issue #261 
In response to #391 

I incorporated the changes into the dev branch. I modeled the changes around KEY_SKIP_SCORPIO.
Much like the last commit, I am skipping the internal logic of lineage assignment and utilizing the expansion function on the final lineage.
I edited the header in report_collation.py without attempting to update the config FINAL_HEADER. Perhaps editing FINAL_HEADER would be preferable?
