### PR TITLE
Avoid using `<(cat ...)` (i.e. `/dev/fd/63` file descriptor) due to compatibility reason

### DIFF
--- a/pangolin/scripts/usher.smk
+++ b/pangolin/scripts/usher.smk
@@ -81,6 +81,7 @@ rule usher_inference:
         reference = config[KEY_REFERENCE_FASTA],
         usher_protobuf = config[KEY_USHER_PB]
     params:
+        ref_fa = os.path.join(config[KEY_TEMPDIR], "sequences.withref.fa"),
         vcf = os.path.join(config[KEY_TEMPDIR], "sequences.aln.vcf")
     threads: workflow.cores
     output:
@@ -91,7 +92,10 @@ rule usher_inference:
         """
         echo "Using UShER as inference engine."
         if [ -s {input.fasta:q} ]; then
-            faToVcf -includeNoAltN <(cat {input.reference:q} <(echo "") {input.fasta:q}) {params.vcf:q}
+            cat {input.reference:q} > {params.ref_fa:q}
+            echo >> {params.ref_fa:q}
+            cat {input.fasta:q} >> {params.ref_fa:q}
+            faToVcf -includeNoAltN {params.ref_fa:q} {params.vcf:q}
             usher -n -D -i {input.usher_protobuf:q} -v {params.vcf:q} -T {workflow.cores} -d '{config[tempdir]}' &> {log}
         else
             rm -f {output.txt:q}


### PR DESCRIPTION
The Pangolin service used by our team is deployed on AWS Lambda. We found that after upgraded to version 4.0, Pangolin started crash on cloud service but work fine locally.

The issue was tracked down to an error message "`cat: /dev/fd/63: No such file or directory`" (detail described here: aws/aws-sam-cli#622; It seems AWS Lambda blocks `/dev/fd` access 👀). We managed to locate the line that caused this issue and proposed a simple fix: we can use a temporary file instead of the pipe file descriptor by `/dev/fd`.

The issue is now solved from our end by [using a fork from this repository](https://github.com/hivdb/pangolin-lambda/commit/c01f17dc5de5008fa5f20cbc01db3688678b0768). We'd like to contribute it back to the main repository. 