### PR TITLE
Ignore Unassigned from cache

### DIFF
--- a/pangolin/scripts/usher.smk
+++ b/pangolin/scripts/usher.smk
@@ -58,7 +58,7 @@ rule usher_cache:
                 writer.writeheader()
                 for row in reader:
                     hash = row["hash"]
-                    if hash in seqs_to_assign:
+                    if hash in seqs_to_assign and row["lineage"] != UNASSIGNED_LINEAGE_REPORTED:
                         cache_note = "Assigned from cache"
                         if not row["note"]:
                             row["note"] = cache_note


### PR DESCRIPTION
Ignore cache row if lineage is Unassigned (because of QC failure when cache was created).  Otherwise, in generate_final_report, scorpio override logic's expanded_pango_lineage.startswith() gets an exception because 'Unassigned' expands to None.  

(In the next cache build I will exclude rows with Unassigned; currently there are 68395 out of 7641517.)

Fixes #410