### PR TITLE
Check draft and prerelease flags to get latest stable release.

### DIFF
--- a/pangolin/utils/update.py
+++ b/pangolin/utils/update.py
@@ -37,9 +37,16 @@ def get_latest_release(dependency):
         sys.exit(-1)
 
     latest_release = json.load(latest_release)
-    latest_release_tarball = latest_release[0]['tarball_url']
+    try:
+        # Find the latest stable release
+        latest_release_dict = next(x for x in latest_release if not x['draft'] and not x['prerelease'])
+    except:
+        # All releases to date are prerelease or draft, just take the latest
+        latest_release_dict = latest_release[0]
+    latest_release_tarball = latest_release_dict['tarball_url']
     # extract and clean up latest release version
-    latest_release = latest_release[0]['tag_name']
+    latest_release = latest_release_dict['tag_name']
+    print(f"Latest for {dependency} is {latest_release}")
     return latest_release, latest_release_tarball
 
 


### PR DESCRIPTION
Currently pangolin-data and pangolin-assignment have pre-releases for v1.3, but their latest stable release tags are v1.2.133.2 and v1.2.133.1 respectively.  However, pangolin v4.0.2's get_latest_release simply takes the first release described by a github API query like https://api.github.com/repos/cov-lineages/pangolin-data/releases without checking whether its prerelease or draft flags are set.  So while v1.3 is intended to be in a pre-release state, anyone doing a `pangolin --update-data` today is getting v1.3.  

This change filters out release descriptions in the github API response if they have the draft or prerelease flag set, so get_latest_release returns the latest stable release as intended.  (Until a few minutes ago, all pangolin-assignment releases were still in the pre-release state, so there is an exception for that case: if no releases have been marked as stable then the latest release of any kind is returned.)