### PR TITLE
Install pangolin-assignment from UCSC download server instead of github

### DIFF
--- a/pangolin/utils/data_checks.py
+++ b/pangolin/utils/data_checks.py
@@ -95,13 +95,6 @@ def get_assignment_cache(cache_file, config):
                               'pangolin-assignment repository (that will make future data updates slower).\n'))
         sys.exit(-1)
 
-    # Check versions of pangolin-data and pangolin-assignment to make sure they are consistent.
-    if pangolin_assignment.__version__.lstrip('v') != config[KEY_PANGOLIN_DATA_VERSION].lstrip('v'):
-        print(cyan(f'Error: pangolin_assignment cache version {pangolin_assignment.__version__} '
-                   f'does not match pangolin_data version {config[KEY_PANGOLIN_DATA_VERSION]}. '
-                   'Run "pangolin --update-data" to fetch latest versions of both.'))
-        sys.exit(-1)
-
     try:
         with gzip.open(cache, 'rt') as f:
             line = f.readline()

--- a/pangolin/utils/update.py
+++ b/pangolin/utils/update.py
@@ -15,7 +15,7 @@ from pangolin.utils.log_colours import green,cyan,red
 
 version_dict_keys = ['pangolin', 'scorpio', 'pangolin-data', 'constellations', 'pangolin-assignment']
 
-dependency_web_dir = { 'pangolin-assignment': 'https://hgdownload-test.gi.ucsc.edu/goldenPath/wuhCor1/pangolin-assignment' }
+dependency_web_dir = { 'pangolin-assignment': 'https://hgdownload.gi.ucsc.edu/goldenPath/wuhCor1/pangolin-assignment' }
 
 
 def get_latest_cov_lineages(dependency):
@@ -32,8 +32,8 @@ def get_latest_cov_lineages(dependency):
     # so if this is thrown and there is definitely connectivity then
     # double check the version labels
     except Exception as e:
-        sys.stderr.write(cyan("Unable to connect to reach github API "
-                               "--update/--data_update requires internet "
+        sys.stderr.write(cyan("Unable to connect to reach github API. "
+                               "--update/--update-data requires internet "
                                "connectivity so may not work on certain "
                                "systems or if your IP has exceeded the "
                               f"5,000 request per hour limit\n{e}\n"))


### PR DESCRIPTION
Up to this point, all data dependencies have been github cov-lineages repositories.  The cache file in pangolin-assignment exceeded the github file size limit so we changed the pangolin-assignment repository to use git-lfs.  Thanks @pvanheus for pointing out that github has storage and bandwidth quotas for Git LFS usage, and that by default the pangolin-assignment release tarball from github does not include the cache file; it can be added to the release tarball, but will count further against the storage and bandwidth quotas.

Since the cache file is generated at UCSC which has ample web server storage and bandwidth, this adds a new mechanism to search for the latest versioned tarball in a web directory (instead of querying the github API), compare its version to the locally installed package if present (using the same pip/`__init__.py` `__version__` mechanism), and install the tarball from the web directory (instead of github).

### Synchronizing release with pangolin-data ###
Ideally, releases of pangolin-data and pangolin-assignment will be synchronized, i.e. released at the same time with the same pango-designation version.  When both are github repositories, that is pretty straightforward to manage using the github interface.  However, when pangolin-assignment changes to a UCSC web directory, "release" for pangolin-assignment means that a new file is copied into https://hgdownload.gi.ucsc.edu/goldenPath/wuhCor1/pangolin-assignment/ (which usually must be done by sys admins at UCSC although I can request special privileges to add files there).  *If* this PR is merged, then @aineniamh and I will have to coordinate more closely to make sure that updates to pangolin-data and pangolin-assignment are released at the same time.