### PR TITLE
Fix --min-length parameter help

### DIFF
--- a/pangolin/command.py
+++ b/pangolin/command.py
@@ -72,7 +72,7 @@ Finally, it is possible to skip the UShER/ pangoLEARN step by selecting "scorpio
     a_group.add_argument("--skip-scorpio", action='store_true', default=False, help="Developer option - do not use scorpio to check VOC/VUI lineage assignments.",dest="skip_scorpio")
 
     a_group.add_argument('--max-ambig', action="store", type=float,help="Maximum proportion of Ns allowed for pangolin to attempt assignment. Default: 0.3",dest="maxambig")
-    a_group.add_argument('--min-length', action="store", type=int,help="Minimum query length allowed for pangolin to attempt assignment. Default: 25000",dest="minlen")
+    a_group.add_argument('--min-length', action="store", type=int,help="Minimum query length excluding Ns allowed for pangolin to attempt assignment. Default: 0 (use --max-ambig)",dest="minlen")
     a_group.add_argument('--usher', action='store_true', default=False, help=argparse.SUPPRESS)
 
     d_group = parser.add_argument_group('Data options')


### PR DESCRIPTION
In the current implementation the default for --min-length is 0 instead of 25000, i.e. running pangolin without --min-length and with `--min-length 25000` (which evaluates to a maximum ambiguity of 0.164) is not equivalent.