### PR TITLE
Extend pangolin --all-versions to report conda versions of important dependencies

### DIFF
--- a/pangolin/utils/update.py
+++ b/pangolin/utils/update.py
@@ -59,8 +59,9 @@ def git_lfs_install():
                    check=True,
                    stdout=subprocess.DEVNULL,
                    stderr=subprocess.DEVNULL)
-    except CalledProcessError as e:
-        sys.stderr.write(cyan(f'Error: "git-lfs install" failed: {e}'))
+    except subprocess.CalledProcessError as e:
+        stderr = e.stderr.decode('utf-8')
+        sys.stderr.write(cyan(f"Error: {e}:\n{stderr}\n"))
         sys.exit(-1)
 
 def pip_install_dep(dependency, release):


### PR DESCRIPTION
This adds versions extracted from `conda list <dependency>` for usher, ucsc-fatovcf, gofasta and minimap2 to the output of `pangolin --all-versions` so it now looks like this (plus pangolin-assignment version if assignment cache has been added):

```
pangolin: 4.0.6
pangolin-data: 1.6
constellations: v0.1.8
scorpio: 0.3.17
usher: 0.5.4
ucsc-fatovcf: 426
gofasta: 1.0.0
minimap2: 2.24
```

refs #439