### PR TITLE
Make pango-assignments work with datadir

### DIFF
--- a/.github/workflows/pangolin.yml
+++ b/.github/workflows/pangolin.yml
@@ -55,4 +55,13 @@ jobs:
         run: pangolin --update-data   2>&1  | tee pangolin_update_data.log
       - name: Run pangolin verbose mode
         run: pangolin --verbose  pangolin/test/test_seqs.fasta  2>&1  | tee pangolin_verbose.log
-
+      - name: Add assignment cache
+        run: pangolin --add-assignment-cache
+      - name: Test use-assignment-cache
+        run: pangolin --use-assignment-cache pangolin/test/test_seqs.fasta 2>&1 | grep 'Using pangolin-assignment cache'
+      - name: remove assignment cache
+        run: pip uninstall -y pangolin-assignment
+      - name: Add assignment cache to datadir
+        run: mkdir ac && pangolin --add-assignment-cache --datadir ac
+      - name: Test use-assignment-cache with datadir
+        run: pangolin --use-assignment-cache --datadir ac pangolin/test/test_seqs.fasta 2>&1 | grep 'Using pangolin-assignment cache'

--- a/pangolin/command.py
+++ b/pangolin/command.py
@@ -4,17 +4,17 @@ from pangolin import __version__
 from pangolin.utils import data_checks
 try:
     import pangolin_data
-except:
+except ImportError:
     data_checks.install_error("pangolin_data", "https://github.com/cov-lineages/pangolin-data.git")
 
 try:
     import scorpio
-except:
+except ImportError:
     data_checks.install_error("scorpio", "https://github.com/cov-lineages/scorpio.git")
 
 try:
     import constellations
-except:
+except ImportError:
     data_checks.install_error("constellations", "https://github.com/cov-lineages/constellations.git")
 
 import os
@@ -110,20 +110,22 @@ Finally, it is possible to skip the UShER/ pangoLEARN step by selecting "scorpio
     setup_data(args.datadir,config[KEY_ANALYSIS_MODE], config)
 
     if args.add_assignment_cache:
-        update.install_pangolin_assignment()
+        update.install_pangolin_assignment(config[KEY_PANGOLIN_ASSIGNMENT_VERSION], args.datadir)
 
     if args.update:
         version_dictionary = {'pangolin': __version__,
                               'pangolin-data': config[KEY_PANGOLIN_DATA_VERSION],
                               'constellations': config[KEY_CONSTELLATIONS_VERSION],
                               'scorpio': config[KEY_SCORPIO_VERSION]}
-        update.add_pangolin_assignment_if_installed(version_dictionary)
+        if config[KEY_PANGOLIN_ASSIGNMENT_VERSION] is not None:
+            version_dictionary['pangolin-assignment'] = config[KEY_PANGOLIN_ASSIGNMENT_VERSION]
         update.update(version_dictionary)
 
     if args.update_data:
         version_dictionary = {'pangolin-data': config[KEY_PANGOLIN_DATA_VERSION],
                               'constellations': config[KEY_CONSTELLATIONS_VERSION]}
-        update.add_pangolin_assignment_if_installed(version_dictionary)
+        if config[KEY_PANGOLIN_ASSIGNMENT_VERSION] is not None:
+            version_dictionary['pangolin-assignment'] = config[KEY_PANGOLIN_ASSIGNMENT_VERSION]
         update.update(version_dictionary, args.datadir)
 
     # install_pangolin_assignment doesn't exit so that --update/--update-data can be given at the

--- a/pangolin/utils/config.py
+++ b/pangolin/utils/config.py
@@ -40,6 +40,8 @@ KEY_PANGOLIN_DATA_VERSION="pangolin_data_version"
 KEY_PANGOLIN_VERSION="pangolin_version"
 KEY_CONSTELLATIONS_VERSION="constellation_version"
 KEY_SCORPIO_VERSION="scorpio_version"
+KEY_PANGOLIN_ASSIGNMENT_VERSION="pangolin_assignment_version"
+KEY_PANGOLIN_ASSIGNMENT_PATH="pangolin_assignment_path"
 
 KEY_VERBOSE="verbose"
 KEY_LOG_API = "log_api"

--- a/pangolin/utils/data_checks.py
+++ b/pangolin/utils/data_checks.py
@@ -95,13 +95,6 @@ def get_assignment_cache(cache_file, config):
                               'pangolin-assignment repository (that will make future data updates slower).\n'))
         sys.exit(-1)
 
-    # Check versions of pangolin-data and pangolin-assignment to make sure they are consistent.
-    if pangolin_assignment.__version__.lstrip('v') != config[KEY_PANGOLIN_DATA_VERSION].lstrip('v'):
-        print(cyan(f'Error: pangolin_assignment cache version {pangolin_assignment.__version__} '
-                   f'does not match pangolin_data version {config[KEY_PANGOLIN_DATA_VERSION]}. '
-                   'Run "pangolin --update-data" to fetch latest versions of both.'))
-        sys.exit(-1)
-
     try:
         with gzip.open(cache, 'rt') as f:
             line = f.readline()

--- a/pangolin/utils/data_checks.py
+++ b/pangolin/utils/data_checks.py
@@ -79,9 +79,8 @@ def install_error(package, url):
 
 def get_assignment_cache(cache_file, config):
     cache = ""
-    try:
-        import pangolin_assignment
-        pangolin_assignment_dir = pangolin_assignment.__path__[0]
+    if config[KEY_PANGOLIN_ASSIGNMENT_VERSION] is not None:
+        pangolin_assignment_dir = config[KEY_PANGOLIN_ASSIGNMENT_PATH]
         for r, d, f in os.walk(pangolin_assignment_dir):
             for fn in f:
                 if fn == cache_file and cache == "":
@@ -89,7 +88,7 @@ def get_assignment_cache(cache_file, config):
         if not os.path.exists(cache):
             sys.stderr.write(cyan(f'Error: cannot find assignment cache file {cache_file} in pangolin_assignment\n'))
             sys.exit(-1)
-    except:
+    else:
         sys.stderr.write(cyan('\nError: "pangolin --add-assignment-cache" is required before '
                               '"pangolin --use-assignment-cache", in order to install optional '
                               'pangolin-assignment repository (that will make future data updates slower).\n'))
@@ -100,6 +99,7 @@ def get_assignment_cache(cache_file, config):
             line = f.readline()
     except:
         with open(cache, 'r') as f:
+            # this is legacy code from when the assignment cache was installed using pip and git-lfs
             line = f.readline()
             if "git-lfs.github.com" in line:
                 sys.stderr.write(cyan(

--- a/pangolin/utils/initialising.py
+++ b/pangolin/utils/initialising.py
@@ -11,6 +11,15 @@ from pangolin.utils.data_checks import *
 from pangolin import __version__
 
 import pangolin_data
+pangolin_assignment_version = None
+pangolin_assignment_path = None
+try:
+    import pangolin_assignment
+    pangolin_assignment_version = pangolin_assignment.__version__
+    pangolin_assignment_path = pangolin_assignment.__path__[0]
+except ImportError:
+    # if we can't import the module, leave the variables as None
+    pass
 import scorpio
 import constellations
 
@@ -52,7 +61,9 @@ def setup_config_dict(cwd):
             KEY_PANGOLIN_DATA_VERSION: pangolin_data.__version__,
             KEY_SCORPIO_VERSION: scorpio.__version__,
             KEY_CONSTELLATIONS_VERSION: constellations.__version__,
-
+            KEY_PANGOLIN_ASSIGNMENT_VERSION: pangolin_assignment_version,
+            KEY_PANGOLIN_ASSIGNMENT_PATH: pangolin_assignment_path,
+            
             KEY_VERBOSE: False,
             KEY_LOG_API: "",
             KEY_THREADS: 1
@@ -116,7 +127,9 @@ def version_from_init(init_file):
                 break
     return version
 
-def setup_data(datadir_arg,analysis_mode, config):
+def setup_data(datadir_arg, analysis_mode, config):
+    global pangolin_assignment_version
+    global pangolin_assignment_path
 
     datadir = check_datadir(datadir_arg)
 
@@ -143,6 +156,8 @@ def setup_data(datadir_arg,analysis_mode, config):
                 constellation_files.append(os.path.join(r, fn))
 
     pangolin_data_version = pangolin_data.__version__
+    
+    # pangolin_assignment_version and pangolin_assignment_path are set at module import time
     use_datadir = False
     datadir_too_old = False
     if datadir:
@@ -150,7 +165,7 @@ def setup_data(datadir_arg,analysis_mode, config):
         for r,d,f in os.walk(datadir):
             for fn in f:
                 # pangolin-data/__init__.py not constellations/__init__.py:
-                if r.endswith('data') and fn == "__init__.py":
+                if r.endswith('/pangolin_data') and fn == "__init__.py":
                     # print("Found " + os.path.join(r, fn))
                     version = version_from_init(os.path.join(r, fn))
                     if not version:
@@ -162,8 +177,19 @@ def setup_data(datadir_arg,analysis_mode, config):
                         use_datadir = True
                     else:
                         datadir_too_old = True
-                        sys.stderr.write(cyan(f"Warning: Ignoring specified datadir {datadir} - it contains pangoLEARN model files older ({version}) than those installed ({pangolin_data.__version__})\n"))
+                        sys.stderr.write(cyan(f"Warning: Ignoring pangolin data in specified datadir {datadir} - it contains pangolin_data older ({version}) than those installed ({pangolin_data.__version__})\n"))
+                elif r.endswith('/pangolin_assignment') and fn == '__init__.py':
+                    version = version_from_init(os.path.join(r, fn))
+                    if not version:
+                        continue
 
+                    if pangolin_assignment_version is None or LooseVersion(version) >= LooseVersion(pangolin_assignment_version):
+                            # only use this if the version is >= than what we already have
+                            pangolin_assignment_version = version
+                            pangolin_assignment_path = r
+                    else:
+                        datadir_too_old = True
+                        sys.stderr.write(cyan(f"Warning: Ignoring pangolin assignment in specified datadir {datadir} - it contains pangolin_assignment older ({version}) than those installed ({pangolin_assignment.__version__})\n"))
     if use_datadir == False:
         # we haven't got a viable datadir from searching args.datadir
         if datadir and not datadir_too_old:
@@ -175,8 +201,10 @@ def setup_data(datadir_arg,analysis_mode, config):
 
     config[KEY_PANGOLIN_DATA_VERSION] = pangolin_data_version
     config[KEY_CONSTELLATIONS_VERSION] = constellations_version
-    config[KEY_DATADIR] = datadir
+    config[KEY_DATADIR] = datadir  # this is the pangolin_data datadir, the naming is from when there was only a single datadir to worry about
     config[KEY_CONSTELLATION_FILES] = constellation_files
+    config[KEY_PANGOLIN_ASSIGNMENT_VERSION] = pangolin_assignment_version
+    config[KEY_PANGOLIN_ASSIGNMENT_PATH] = pangolin_assignment_path
 
 def parse_qc_thresholds(maxambig, minlen, reference_fasta, config):
     
@@ -225,7 +253,7 @@ def print_versions_exit(config):
     # Report pangolin_assignment version if it is installed, otherwise ignore
     try:
         import pangolin_assignment
-        print(f"pangolin-assignment: {pangolin_assignment.__version__}")
+        print(f"pangolin-assignment: {config[KEY_PANGOLIN_ASSIGNMENT_VERSION]}")
     except:
         pass
     sys.exit(0)

--- a/pangolin/utils/initialising.py
+++ b/pangolin/utils/initialising.py
@@ -176,7 +176,6 @@ def setup_data(datadir_arg, analysis_mode, config):
                         pangolin_data_version = version
                         use_datadir = True
                     else:
-                        datadir_too_old = True
                         sys.stderr.write(cyan(f"Warning: Ignoring pangolin data in specified datadir {datadir} - it contains pangolin_data older ({version}) than those installed ({pangolin_data.__version__})\n"))
                 elif r.endswith('/pangolin_assignment') and fn == '__init__.py':
                     version = version_from_init(os.path.join(r, fn))
@@ -188,14 +187,8 @@ def setup_data(datadir_arg, analysis_mode, config):
                             pangolin_assignment_version = version
                             pangolin_assignment_path = r
                     else:
-                        datadir_too_old = True
-                        sys.stderr.write(cyan(f"Warning: Ignoring pangolin assignment in specified datadir {datadir} - it contains pangolin_assignment older ({version}) than those installed ({pangolin_assignment.__version__})\n"))
+\                        sys.stderr.write(cyan(f"Warning: Ignoring pangolin assignment in specified datadir {datadir} - it contains pangolin_assignment older ({version}) than those installed ({pangolin_assignment.__version__})\n"))
     if use_datadir == False:
-        # we haven't got a viable datadir from searching args.datadir
-        if datadir and not datadir_too_old:
-            sys.stderr.write(cyan(
-                f"Warning: Ignoring specified datadir {datadir} - could not find __init__.py file to check versions \n"))
-
         pangolin_data_dir = pangolin_data.__path__[0]
         datadir = os.path.join(pangolin_data_dir,"data")
 
@@ -233,11 +226,10 @@ def parse_qc_thresholds(maxambig, minlen, reference_fasta, config):
         
     print(green(f"Maximum ambiguity allowed is {config[KEY_MAXAMBIG]}.\n****"))
 
-
 def print_ram_warning(analysis_mode):
     if analysis_mode == "pangolearn":
         print(cyan("Warning: pangoLEARN mode may use a significant amount of RAM, be aware that it will not suit every system."))
-    
+
 def print_alias_file_exit(alias_file):
     with open(alias_file, 'r') as handle:
         for line in handle:

--- a/pangolin/utils/initialising.py
+++ b/pangolin/utils/initialising.py
@@ -187,7 +187,7 @@ def setup_data(datadir_arg, analysis_mode, config):
                             pangolin_assignment_version = version
                             pangolin_assignment_path = r
                     else:
-\                        sys.stderr.write(cyan(f"Warning: Ignoring pangolin assignment in specified datadir {datadir} - it contains pangolin_assignment older ({version}) than those installed ({pangolin_assignment.__version__})\n"))
+                        sys.stderr.write(cyan(f"Warning: Ignoring pangolin assignment in specified datadir {datadir} - it contains pangolin_assignment older ({version}) than those installed ({pangolin_assignment.__version__})\n"))
     if use_datadir == False:
         pangolin_data_dir = pangolin_data.__path__[0]
         datadir = os.path.join(pangolin_data_dir,"data")

--- a/pangolin/utils/update.py
+++ b/pangolin/utils/update.py
@@ -15,7 +15,7 @@ from pangolin.utils.log_colours import green,cyan,red
 
 version_dict_keys = ['pangolin', 'scorpio', 'pangolin-data', 'constellations', 'pangolin-assignment']
 
-dependency_web_dir = { 'pangolin-assignment': 'https://hgdownload-test.gi.ucsc.edu/goldenPath/wuhCor1/pangolin-assignment' }
+dependency_web_dir = { 'pangolin-assignment': 'https://hgdownload.gi.ucsc.edu/goldenPath/wuhCor1/pangolin-assignment' }
 
 
 def get_latest_cov_lineages(dependency):
@@ -32,8 +32,8 @@ def get_latest_cov_lineages(dependency):
     # so if this is thrown and there is definitely connectivity then
     # double check the version labels
     except Exception as e:
-        sys.stderr.write(cyan("Unable to connect to reach github API "
-                               "--update/--data_update requires internet "
+        sys.stderr.write(cyan("Unable to connect to reach github API. "
+                               "--update/--update-data requires internet "
                                "connectivity so may not work on certain "
                                "systems or if your IP has exceeded the "
                               f"5,000 request per hour limit\n{e}\n"))

--- a/pangolin/utils/update.py
+++ b/pangolin/utils/update.py
@@ -104,29 +104,21 @@ def pip_install_cov_lineages(dependency, release):
     pip_install_url(url)
 
 
-def install_pangolin_assignment():
+def install_pangolin_assignment(pangolin_assignment_version, datadir):
     """
     If the pangolin-assignment repo has not been installed already then install the latest release.
     """
-    try:
-        import pangolin_assignment
-        print(f"pangolin-assignment already installed with version {pangolin_assignment.__version__}; use --update or --update-data if you wish to update it.", file=sys.stderr)
-
-    except:
+    if pangolin_assignment_version is not None:
+        print(f"pangolin-assignment already installed with version {pangolin_assignment_version}; use --update or --update-data if you wish to update it.", file=sys.stderr)
+    else:
         latest_release, tarball = get_latest_release('pangolin-assignment')
-        pip_install_url(tarball)
+        if datadir is not None and os.path.exists(datadir):
+            # install pangolin-assignment to datadir instead of using pip install
+            version_dictionary = {'pangolin-assignment': '0'}
+            update(version_dictionary, datadir)
+        else:
+            pip_install_url(tarball)
         print(f"pangolin-assignment installed with latest release ({latest_release})")
-
-
-def add_pangolin_assignment_if_installed(version_dictionary):
-    """
-    If pangolin_assignment has been installed then add it to version_dictionary, else ignore.
-    """
-    try:
-        import pangolin_assignment
-        version_dictionary["pangolin-assignment"] = pangolin_assignment.__version__
-    except:
-        pass
 
 
 def update(version_dictionary, data_dir=None):


### PR DESCRIPTION
This incorporates #430 and also:

1. Load the pangolin assignment cache from datadir if it is present and newer than the already-installed version
2. If add-assignment-cache and datadir are both specified, download the assignment cache into datadir
3. If update or update-data are specified together with datadir, put updated versions of the data in datadir

(it is here as its own PR so that I can check that the CI testing passes)