### PR TITLE
Allow assignment cache to be saved to and loaded from datadir

### DIFF
--- a/.github/workflows/pangolin.yml
+++ b/.github/workflows/pangolin.yml
@@ -55,4 +55,13 @@ jobs:
         run: pangolin --update-data   2>&1  | tee pangolin_update_data.log
       - name: Run pangolin verbose mode
         run: pangolin --verbose  pangolin/test/test_seqs.fasta  2>&1  | tee pangolin_verbose.log
-
+      - name: Add assignment cache
+        run: pangolin --add-assignment-cache
+      - name: Test use-assignment-cache
+        run: pangolin --use-assignment-cache pangolin/test/test_seqs.fasta 2>&1 | grep 'Using pangolin-assignment cache'
+      - name: remove assignment cache
+        run: pip uninstall -y pangolin-assignment
+      - name: Add assignment cache to datadir
+        run: mkdir ac && pangolin --add-assignment-cache --datadir ac
+      - name: Test use-assignment-cache with datadir
+        run: pangolin --use-assignment-cache --datadir ac pangolin/test/test_seqs.fasta 2>&1 | grep 'Using pangolin-assignment cache'

--- a/pangolin/command.py
+++ b/pangolin/command.py
@@ -4,17 +4,17 @@ from pangolin import __version__
 from pangolin.utils import data_checks
 try:
     import pangolin_data
-except:
+except ImportError:
     data_checks.install_error("pangolin_data", "https://github.com/cov-lineages/pangolin-data.git")
 
 try:
     import scorpio
-except:
+except ImportError:
     data_checks.install_error("scorpio", "https://github.com/cov-lineages/scorpio.git")
 
 try:
     import constellations
-except:
+except ImportError:
     data_checks.install_error("constellations", "https://github.com/cov-lineages/constellations.git")
 
 import os
@@ -110,20 +110,22 @@ Finally, it is possible to skip the UShER/ pangoLEARN step by selecting "scorpio
     setup_data(args.datadir,config[KEY_ANALYSIS_MODE], config)
 
     if args.add_assignment_cache:
-        update.install_pangolin_assignment()
+        update.install_pangolin_assignment(config[KEY_PANGOLIN_ASSIGNMENT_VERSION], args.datadir)
 
     if args.update:
         version_dictionary = {'pangolin': __version__,
                               'pangolin-data': config[KEY_PANGOLIN_DATA_VERSION],
                               'constellations': config[KEY_CONSTELLATIONS_VERSION],
                               'scorpio': config[KEY_SCORPIO_VERSION]}
-        update.add_pangolin_assignment_if_installed(version_dictionary)
+        if config[KEY_PANGOLIN_ASSIGNMENT_VERSION] is not None:
+            version_dictionary['pangolin-assignment'] = config[KEY_PANGOLIN_ASSIGNMENT_VERSION]
         update.update(version_dictionary)
 
     if args.update_data:
         version_dictionary = {'pangolin-data': config[KEY_PANGOLIN_DATA_VERSION],
                               'constellations': config[KEY_CONSTELLATIONS_VERSION]}
-        update.add_pangolin_assignment_if_installed(version_dictionary)
+        if config[KEY_PANGOLIN_ASSIGNMENT_VERSION] is not None:
+            version_dictionary['pangolin-assignment'] = config[KEY_PANGOLIN_ASSIGNMENT_VERSION]
         update.update(version_dictionary, args.datadir)
 
     # install_pangolin_assignment doesn't exit so that --update/--update-data can be given at the

--- a/pangolin/command.py
+++ b/pangolin/command.py
@@ -81,7 +81,7 @@ Finally, it is possible to skip the UShER/ pangoLEARN step by selecting "scorpio
     d_group.add_argument('--add-assignment-cache', action='store_true', dest="add_assignment_cache", default=False, help="Install the pangolin-assignment repository for use with --use-assignment-cache.  This makes updates slower and makes pangolin slower for small numbers of input sequences but much faster for large numbers of input sequences.")
     d_group.add_argument('--use-assignment-cache', action='store_true', dest="use_assignment_cache", default=False, help="Use assignment cache from optional pangolin-assignment repository. NOTE: the repository must be installed by --add-assignment-cache before using --use-assignment-cache.")
     d_group.add_argument('-d', '--datadir', action='store',dest="datadir",help="Data directory minimally containing the pangoLEARN model, header files and UShER tree. Default: Installed pangolin-data package.")
-    d_group.add_argument('--use_old_datadir', action='store_true', default=False, help="Use the data from data directory even if older than data installed via Python packages. Default: False")
+    d_group.add_argument('--use-old-datadir', action='store_true', default=False, help="Use the data from data directory even if older than data installed via Python packages. Default: False")
     d_group.add_argument('--usher-tree', action='store', dest='usher_protobuf', help="UShER Mutation Annotated Tree protobuf file to use instead of default from pangolin-data repository or --datadir.")
     d_group.add_argument('--assignment-cache', action='store', dest='assignment_cache', help="Cached precomputed assignment file to use instead of default from pangolin-assignment repository.  Does not require installation of pangolin-assignment.")
 

--- a/pangolin/command.py
+++ b/pangolin/command.py
@@ -81,6 +81,7 @@ Finally, it is possible to skip the UShER/ pangoLEARN step by selecting "scorpio
     d_group.add_argument('--add-assignment-cache', action='store_true', dest="add_assignment_cache", default=False, help="Install the pangolin-assignment repository for use with --use-assignment-cache.  This makes updates slower and makes pangolin slower for small numbers of input sequences but much faster for large numbers of input sequences.")
     d_group.add_argument('--use-assignment-cache', action='store_true', dest="use_assignment_cache", default=False, help="Use assignment cache from optional pangolin-assignment repository. NOTE: the repository must be installed by --add-assignment-cache before using --use-assignment-cache.")
     d_group.add_argument('-d', '--datadir', action='store',dest="datadir",help="Data directory minimally containing the pangoLEARN model, header files and UShER tree. Default: Installed pangolin-data package.")
+    d_group.add_argument('--use_old_datadir', action='store_true', default=False, help="Use the data from data directory even if older than data installed via Python packages. Default: False")
     d_group.add_argument('--usher-tree', action='store', dest='usher_protobuf', help="UShER Mutation Annotated Tree protobuf file to use instead of default from pangolin-data repository or --datadir.")
     d_group.add_argument('--assignment-cache', action='store', dest='assignment_cache', help="Cached precomputed assignment file to use instead of default from pangolin-assignment repository.  Does not require installation of pangolin-assignment.")
 
@@ -107,7 +108,7 @@ Finally, it is possible to skip the UShER/ pangoLEARN step by selecting "scorpio
     if args.usher:
         sys.stderr.write(cyan(f"--usher is a pangolin v3 option and is deprecated in pangolin v4.  UShER is now the default analysis mode.  Use --analysis-mode to explicitly set mode.\n"))
 
-    setup_data(args.datadir,config[KEY_ANALYSIS_MODE], config)
+    setup_data(args.datadir,config[KEY_ANALYSIS_MODE], config, args.use_old_datadir)
 
     if args.add_assignment_cache:
         update.install_pangolin_assignment(config[KEY_PANGOLIN_ASSIGNMENT_VERSION], args.datadir)

--- a/pangolin/utils/config.py
+++ b/pangolin/utils/config.py
@@ -40,6 +40,8 @@ KEY_PANGOLIN_DATA_VERSION="pangolin_data_version"
 KEY_PANGOLIN_VERSION="pangolin_version"
 KEY_CONSTELLATIONS_VERSION="constellation_version"
 KEY_SCORPIO_VERSION="scorpio_version"
+KEY_PANGOLIN_ASSIGNMENT_VERSION="pangolin_assignment_version"
+KEY_PANGOLIN_ASSIGNMENT_PATH="pangolin_assignment_path"
 
 KEY_VERBOSE="verbose"
 KEY_LOG_API = "log_api"

--- a/pangolin/utils/data_checks.py
+++ b/pangolin/utils/data_checks.py
@@ -114,5 +114,13 @@ def get_assignment_cache(cache_file, config):
                 sys.exit(-1)
     return cache
 
+def get_constellation_files(path):
+    constellation_files = []
+    for r, _, f in os.walk(path):
+        for fn in f:
+            if (r.endswith('/constellations') or r.endswith('/constellations/definitions')) and fn.endswith('.json'):
+                constellation_files.append(os.path.join(r, fn))
+    return constellation_files
+
 # config={}
 # check_install()

--- a/pangolin/utils/data_checks.py
+++ b/pangolin/utils/data_checks.py
@@ -79,9 +79,8 @@ def install_error(package, url):
 
 def get_assignment_cache(cache_file, config):
     cache = ""
-    try:
-        import pangolin_assignment
-        pangolin_assignment_dir = pangolin_assignment.__path__[0]
+    if config[KEY_PANGOLIN_ASSIGNMENT_VERSION] is not None:
+        pangolin_assignment_dir = config[KEY_PANGOLIN_ASSIGNMENT_PATH]
         for r, d, f in os.walk(pangolin_assignment_dir):
             for fn in f:
                 if fn == cache_file and cache == "":
@@ -89,15 +88,15 @@ def get_assignment_cache(cache_file, config):
         if not os.path.exists(cache):
             sys.stderr.write(cyan(f'Error: cannot find assignment cache file {cache_file} in pangolin_assignment\n'))
             sys.exit(-1)
-    except:
+    else:
         sys.stderr.write(cyan('\nError: "pangolin --add-assignment-cache" is required before '
                               '"pangolin --use-assignment-cache", in order to install optional '
                               'pangolin-assignment repository (that will make future data updates slower).\n'))
         sys.exit(-1)
 
     # Check versions of pangolin-data and pangolin-assignment to make sure they are consistent.
-    if pangolin_assignment.__version__.lstrip('v') != config[KEY_PANGOLIN_DATA_VERSION].lstrip('v'):
-        print(cyan(f'Error: pangolin_assignment cache version {pangolin_assignment.__version__} '
+    if config[KEY_PANGOLIN_ASSIGNMENT_VERSION].lstrip('v') != config[KEY_PANGOLIN_DATA_VERSION].lstrip('v'):
+        print(cyan(f'Error: pangolin_assignment cache version {config[KEY_PANGOLIN_ASSIGNMENT_VERSION]} '
                    f'does not match pangolin_data version {config[KEY_PANGOLIN_DATA_VERSION]}. '
                    'Run "pangolin --update-data" to fetch latest versions of both.'))
         sys.exit(-1)
@@ -107,6 +106,7 @@ def get_assignment_cache(cache_file, config):
             line = f.readline()
     except:
         with open(cache, 'r') as f:
+            # this is legacy code from when the assignment cache was installed using pip and git-lfs
             line = f.readline()
             if "git-lfs.github.com" in line:
                 sys.stderr.write(cyan(

--- a/pangolin/utils/data_checks.py
+++ b/pangolin/utils/data_checks.py
@@ -106,7 +106,6 @@ def get_assignment_cache(cache_file, config):
             line = f.readline()
     except:
         with open(cache, 'r') as f:
-            # this is legacy code from when the assignment cache was installed using pip and git-lfs
             line = f.readline()
             if "git-lfs.github.com" in line:
                 sys.stderr.write(cyan(

--- a/pangolin/utils/initialising.py
+++ b/pangolin/utils/initialising.py
@@ -184,12 +184,16 @@ def setup_data(datadir_arg, analysis_mode, config):
                             pangolin_assignment_version = version
                             pangolin_assignment_path = r
                     else:
+<<<<<<< HEAD
                         sys.stderr.write(cyan(f"Warning: Ignoring pangolin assignment in specified datadir {datadir} - it contains pangolin_assignment older ({version}) than those installed ({pangolin_assignment_version})\n"))
 
     if constellations_version_from_datadir is not None and LooseVersion(constellations_version_from_datadir) > LooseVersion(constellations_version):
         constellation_files = constellation_files_from_datadir
         constellations_version = constellations_version_from_datadir
 
+=======
+\                        sys.stderr.write(cyan(f"Warning: Ignoring pangolin assignment in specified datadir {datadir} - it contains pangolin_assignment older ({version}) than those installed ({pangolin_assignment.__version__})\n"))
+>>>>>>> eba85c9 (Remove useless warning about datadir)
     if use_datadir == False:
         pangolin_data_dir = pangolin_data.__path__[0]
         datadir = os.path.join(pangolin_data_dir,"data")
@@ -228,11 +232,10 @@ def parse_qc_thresholds(maxambig, minlen, reference_fasta, config):
         
     print(green(f"Maximum ambiguity allowed is {config[KEY_MAXAMBIG]}.\n****"))
 
-
 def print_ram_warning(analysis_mode):
     if analysis_mode == "pangolearn":
         print(cyan("Warning: pangoLEARN mode may use a significant amount of RAM, be aware that it will not suit every system."))
-    
+
 def print_alias_file_exit(alias_file):
     with open(alias_file, 'r') as handle:
         for line in handle:

--- a/pangolin/utils/initialising.py
+++ b/pangolin/utils/initialising.py
@@ -184,16 +184,12 @@ def setup_data(datadir_arg, analysis_mode, config):
                             pangolin_assignment_version = version
                             pangolin_assignment_path = r
                     else:
-<<<<<<< HEAD
                         sys.stderr.write(cyan(f"Warning: Ignoring pangolin assignment in specified datadir {datadir} - it contains pangolin_assignment older ({version}) than those installed ({pangolin_assignment_version})\n"))
 
     if constellations_version_from_datadir is not None and LooseVersion(constellations_version_from_datadir) > LooseVersion(constellations_version):
         constellation_files = constellation_files_from_datadir
         constellations_version = constellations_version_from_datadir
 
-=======
-\                        sys.stderr.write(cyan(f"Warning: Ignoring pangolin assignment in specified datadir {datadir} - it contains pangolin_assignment older ({version}) than those installed ({pangolin_assignment.__version__})\n"))
->>>>>>> eba85c9 (Remove useless warning about datadir)
     if use_datadir == False:
         pangolin_data_dir = pangolin_data.__path__[0]
         datadir = os.path.join(pangolin_data_dir,"data")

--- a/pangolin/utils/update.py
+++ b/pangolin/utils/update.py
@@ -68,7 +68,6 @@ def pip_install_dep(dependency, release, datadir=None):
     """
     Use pip install to install a cov-lineages repository with the specificed release
     """
-    env_vars = None
     url = f"git+https://github.com/cov-lineages/{dependency}.git@{release}"
     pip_command = [sys.executable, '-m', 'pip', 'install', '--upgrade']
     if datadir is not None:
@@ -77,8 +76,7 @@ def pip_install_dep(dependency, release, datadir=None):
     subprocess.run(pip_command,
                    check=True,
                    stdout=subprocess.DEVNULL,
-                   stderr=subprocess.DEVNULL,
-                   env=env_vars)
+                   stderr=subprocess.DEVNULL)
 
 
 def install_pangolin_assignment(pangolin_assignment_version, datadir=None):
@@ -91,7 +89,7 @@ def install_pangolin_assignment(pangolin_assignment_version, datadir=None):
         git_lfs_install()
         latest_release, tarball = get_latest_release('pangolin-assignment')
         pip_install_dep('pangolin-assignment', latest_release, datadir)
-
+        print(f"pangolin-assignment installed with latest release ({latest_release})")
 
 def update(version_dictionary, data_dir=None):
     """

--- a/pangolin/utils/update.py
+++ b/pangolin/utils/update.py
@@ -72,7 +72,7 @@ def pip_install_dep(dependency, release, datadir=None):
     url = f"git+https://github.com/cov-lineages/{dependency}.git@{release}"
     pip_command = [sys.executable, '-m', 'pip', 'install', '--upgrade']
     if datadir is not None:
-        pip_command.append('--target', datadir)
+        pip_command.extend(['--target', datadir])
     pip_command.append(url)
     subprocess.run(pip_command,
                    check=True,

--- a/pangolin/utils/update.py
+++ b/pangolin/utils/update.py
@@ -69,10 +69,12 @@ def pip_install_dep(dependency, release, datadir=None):
     Use pip install to install a cov-lineages repository with the specificed release
     """
     env_vars = None
-    if datadir is not None:
-        env_vars = {'PIP_TARGET': datadir, 'PIP_UPGRADE': '1'}
     url = f"git+https://github.com/cov-lineages/{dependency}.git@{release}"
-    subprocess.run([sys.executable, '-m', 'pip', 'install', '--upgrade', url],
+    pip_command = [sys.executable, '-m', 'pip', 'install', '--upgrade']
+    if datadir is not None:
+        pip_command.append('--target', datadir)
+    pip_command.append(url)
+    subprocess.run(pip_command,
                    check=True,
                    stdout=subprocess.DEVNULL,
                    stderr=subprocess.DEVNULL,


### PR DESCRIPTION
* Support download assignment cache to datadir and using from datadir
* Switch to using pip for all installs (thanks for tip from Wolfgang Maier)
* Change logic for finding constellations files to use latest version