### PR TITLE
replace minimap2 temp output file with pipe

### DIFF
--- a/pangolin/scripts/preprocessing.smk
+++ b/pangolin/scripts/preprocessing.smk
@@ -32,9 +32,8 @@ rule align_to_reference:
         #  {{ gsub(" ","_",$0); }} {{ gsub(",","_",$0); }}
         shell_command =  """ | awk '{{ if ($0 !~ /^>/) {{ gsub("-", "",$0); }} print $0; }}'   | \
             awk '{{ {{ gsub(" ", "_",$0); }} {{ gsub(",", "_",$0); }} print $0; }}'  | \
-            minimap2 -a -x asm20 --sam-hit-only --secondary=no --score-N=0  -t  {workflow.cores} {input.reference:q} - -o {params.sam:q} &> {log:q} 
+            minimap2 -a -x asm20 --sam-hit-only --secondary=no --score-N=0  -t  {workflow.cores} {input.reference:q} - 2> {log:q} | \
             gofasta sam toMultiAlign \
-                -s {params.sam:q} \
                 -t {workflow.cores} \
                 --reference {input.reference:q} \
                 --trimstart {params.trim_start} \


### PR DESCRIPTION
I noticed that `minimap2` is writing to a temp file, `mapped.sam`, which is often at least as large as the uncompressed input sequence file. 

This PR eliminates the temporary file by just piping `minimap2` into `gofasta sam toMultiAlign`.