### PR TITLE
Use usher-sampled if installed

### DIFF
--- a/pangolin/scripts/usher.smk
+++ b/pangolin/scripts/usher.smk
@@ -103,8 +103,6 @@ rule usher_inference:
                 echo "*** usher-sampled is not installed -- please upgrade usher to at least v0.6.1 ***"
                 echo "*** If you used conda to install usher, run 'conda update --no-pin usher'     ***"
                 echo "*** Alternatively if mamba is installed, run 'mamba update --no-pin usher'    ***"
-                echo "*** If you use Mac OS X and usher 0.6.1 or later is not yet available, then   ***"
-                echo "*** please pardon the inconvenience but watch for updates.                    ***"
                 echo ""
             fi
             cat {input.fasta:q} >> {params.ref_fa:q}

--- a/pangolin/scripts/usher.smk
+++ b/pangolin/scripts/usher.smk
@@ -101,12 +101,14 @@ rule usher_inference:
             else
                 echo ""
                 echo "*** usher-sampled is not installed -- please upgrade usher to at least v0.6.1 ***"
-                echo "*** If you used conda to install usher, run 'conda update --no-pin usher' ***"
+                echo "*** If you used conda to install usher, run 'conda update --no-pin usher'     ***"
+                echo "*** Alternatively if mamba is installed, run 'mamba update --no-pin usher'    ***"
+                echo "*** If you use Mac OS X and usher 0.6.1 or later is not yet available, then   ***"
+                echo "*** please pardon the inconvenience but watch for updates.                    ***"
                 echo ""
             fi
             cat {input.fasta:q} >> {params.ref_fa:q}
             faToVcf -includeNoAltN {params.ref_fa:q} {params.vcf:q}
-            echo usher command: $usher -n -D -i {input.usher_protobuf:q} -v {params.vcf:q} -T $threads -d '{config[tempdir]}' \&\> {log}
             $usher -n -D -i {input.usher_protobuf:q} -v {params.vcf:q} -T $threads -d '{config[tempdir]}' &> {log}
         else
             rm -f {output.txt:q}

--- a/pangolin/scripts/usher.smk
+++ b/pangolin/scripts/usher.smk
@@ -94,9 +94,20 @@ rule usher_inference:
         if [ -s {input.fasta:q} ]; then
             cat {input.reference:q} > {params.ref_fa:q}
             echo >> {params.ref_fa:q}
+            usher=usher
+            threads={workflow.cores}
+            if usher-sampled --help >& /dev/null; then
+                usher="usher-sampled --optimization_radius 0"
+            else
+                echo ""
+                echo "*** usher-sampled is not installed -- please upgrade usher to at least v0.6.1 ***"
+                echo "*** If you used conda to install usher, run 'conda update --no-pin usher' ***"
+                echo ""
+            fi
             cat {input.fasta:q} >> {params.ref_fa:q}
             faToVcf -includeNoAltN {params.ref_fa:q} {params.vcf:q}
-            usher -n -D -i {input.usher_protobuf:q} -v {params.vcf:q} -T {workflow.cores} -d '{config[tempdir]}' &> {log}
+            echo usher command: $usher -n -D -i {input.usher_protobuf:q} -v {params.vcf:q} -T $threads -d '{config[tempdir]}' \&\> {log}
+            $usher -n -D -i {input.usher_protobuf:q} -v {params.vcf:q} -T $threads -d '{config[tempdir]}' &> {log}
         else
             rm -f {output.txt:q}
             touch {output.txt:q}


### PR DESCRIPTION
[UShER release v0.6.0](https://github.com/yatisht/usher/releases/tag/v0.6.0) includes the new usher-sampled, a much faster version of usher developed by @yceh.  Using usher-sampled instead of usher speeds up pangolin's usher mode dramatically when running on large numbers of input sequences.

Ironically, in order to run with pangolin's default --threads=1 and small numbers of sequences, a couple of small changes were required, so [UShER release v0.6.1](https://github.com/yatisht/usher/releases/tag/v0.6.1) or later should be installed with pangolin.  It is now available from bioconda for linux.  (Looks like 0.5.6 is the most recent version of usher available on Mac.)

This PR changes usher.smk's usher_inference rule to use usher-sampled if it is installed; otherwise, it prints out a message recommending that the user update the usher package, and uses usher as usual.

Not only is usher-sampled faster than usher, it also avoids some overcounting of multiple equally parsimonious placements (e.g. near both parent & siblings but on the same node) and doesn't count an N-match at the end of a placement path as an EPP when there are non-N matches at the ends of other paths.  This helps to reduce some occasional over-specific assignments that depended on Ns or ambiguous bases at the ends of placement paths.