### PR TITLE
Workaround for setup-miniconda failing to install mamba on ubuntu

### DIFF
--- a/.github/workflows/pangolin.yml
+++ b/.github/workflows/pangolin.yml
@@ -18,7 +18,7 @@ jobs:
           environment-file: environment.yml
           activate-environment: pangolin
           channels: conda-forge,bioconda,defaults
-          mamba-version: "*"
+          miniforge-variant: Mambaforge
       - name: Install pangolin
         run: pip install -e .
       - name: Check pangolin version


### PR DESCRIPTION
pangolin github action tests have been failing on ubuntu for about a week now (?) not because of anything in pangolin, but because the conda-incubator/setup-miniconda action's conda command to install mamba fails with a ton of cryptic conflict errors.  I found that removing `mamba-version: "*"` from pangolin.yml would prevent the crash, but it would be nice to keep mamba in the CI too.  I found a nice report of this issue, including suggested workarounds: conda-incubator/setup-miniconda#274 and indeed the first suggested workaround (replacing `mamba-version: "*"` with `miniforge-variant: Mambaforge`) worked.