### PR TITLE
Unpin pip (and snakemake)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,9 +6,9 @@ channels:
 dependencies:
   - biopython>=1.74
   - minimap2>=2.16
-  - pip=19.3.1
+  - pip
   - python>=3.7
-  - snakemake-minimal=7.24.0
+  - snakemake-minimal!=7.30.2
   - gofasta
   - ucsc-fatovcf>=426
   - usher>=0.5.4


### PR DESCRIPTION
I think the reason for failure with snakemake 7.30.2 was that you had pip pinned - not quite sure why. Let's try this way - it should then work also with newest snakemake again, and older ones.

Let's see whether actions pass