### PR TITLE
Remove unmaintained version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM continuumio/miniconda3:4.9.2-alpine
-LABEL version="2.1.2" \
-      description="Docker image for Pangolin"
+LABEL description="Docker image for Pangolin"
 
 # Install git for pangolin
 RUN apk update && \


### PR DESCRIPTION
I think this version label was supposed to be updated with every version - but as it has never been changed, it should be removed so as not to confuse anyone.