### PR TITLE
Add entries for pangolin-data/-assignment 1.23

### DIFF
--- a/pangolin/data/data_compatibility.csv
+++ b/pangolin/data/data_compatibility.csv
@@ -1,4 +1,5 @@
 data_source,version,min_pangolin_version,min_scorpio_version
+pangolin-data,1.23,4.3,
 pangolin-data,1.21,4.3,
 pangolin-data,1.20,4.3,
 pangolin-data,1.19,4,
@@ -18,6 +19,7 @@ pangolin-data,1.6,4,
 pangolin-data,1.3,4,
 pangolin-data,1.2.133,4,
 pangolin-data,1.2.127,4,
+pangolin-assignment,1.23,4.3,
 pangolin-assignment,1.21,4.3,
 pangolin-assignment,1.20,4.3,
 pangolin-assignment,1.19,4,


### PR DESCRIPTION
pangolin-data and pangolin-assignment v1.23 have been released, so this is a routine update to pangolin's list of data compatiblities.

Note: Currently the pangolin test is failing because the v1.23 pangolin-data tree provokes a corner-case bug in usher-sampled (<= v0.6.2) that affects lineage A sequences like outgroup_A in pangolin/test/test_seqs.fasta.  The test failure has nothing to do with this PR.  Hopefully usher v0.6.3 will be released soon, and that should fix the pangolin test failure.