### PR TITLE
conda channels: change defaults to nodefaults

### DIFF
--- a/.github/workflows/pangolin.yml
+++ b/.github/workflows/pangolin.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           environment-file: environment.yml
           activate-environment: pangolin
-          channels: conda-forge,bioconda,defaults
+          channels: conda-forge,bioconda,nodefaults
       - name: Install pangolin
         run: pip install -e .
       - name: Check pangolin version

--- a/.github/workflows/pangolin_macos.yml
+++ b/.github/workflows/pangolin_macos.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           environment-file: environment.yml
           activate-environment: pangolin
-          channels: conda-forge,bioconda,defaults
+          channels: conda-forge,bioconda,nodefaults
           miniconda-version: "latest"
       - name: Install pangolin
         run: pip install -e .

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: pangolin
 channels:
   - conda-forge
   - bioconda
-  - defaults
+  - nodefaults
 dependencies:
   - biopython>=1.74
   - minimap2>=2.16


### PR DESCRIPTION
@ammaraziz pointed out in #562 that the Anaconda defaults channel is unnecessary for building pangolin and can be problematic, so change `defaults` to `nodefaults` in all channel configs in .yml files.