### PR TITLE
Dockerfile: use mamba, update alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM continuumio/miniconda3:4.9.2-alpine
+FROM continuumio/miniconda3:23.5.2-0-alpine
 LABEL version="2.1.2" \
       description="Docker image for Pangolin"
 
+RUN conda install -n base -c conda-forge mamba
 # Install git for pangolin
 RUN apk update && \
     apk add git bash
@@ -12,9 +13,9 @@ COPY environment.yml /environment.yml
 RUN sed -i "$(grep -n 'python>=3.7' /environment.yml | cut -f1 -d:)d" /environment.yml && \
     sed -i "$(grep -n 'pip=' /environment.yml | cut -f1 -d:)d" /environment.yml
 # Install the conda environment
-RUN conda env create --quiet -f /environment.yml && conda clean -a
+RUN mamba env create --quiet -f /environment.yml && conda clean -a
 # Add conda installation dir to PATH (instead of doing 'conda activate')
-ENV PATH /opt/conda/envs/pangolin/bin:$PATH
+ENV PATH=/opt/conda/envs/pangolin/bin:$PATH
 
 # Install Pangolin
 COPY . /pangolin/
@@ -23,5 +24,5 @@ RUN pip install . && rm -rf /root/.cache/pip
 RUN pangolin --version &> /pangolin-version.txt
 
 # Dump the details of the installed packages to a file for posterity
-RUN conda env export --name pangolin > /pangolin.yml
+RUN mamba env export --name pangolin > /pangolin.yml
 WORKDIR /tmp/


### PR DESCRIPTION
Updates from @abel-betraoui in #564: use mamba (faster than conda), use continuumio/miniconda3:23.5.2-0-alpine image instead of old 4.9.2.